### PR TITLE
GH-16: Utility share-for endpoint + outsider policy

### DIFF
--- a/.stan/system/stan.requirements.md
+++ b/.stan/system/stan.requirements.md
@@ -208,8 +208,65 @@ Tailwind v4 with `@theme inline` requires CSS variable indirection:
 | POST | `/api/share` | Cookie (insider) | Generate outsider share link (accepts `depth`, `dirs`) |
 | GET | `/api/readme-link` | None | Pre-computed README share URL |
 | POST | `/api/rotate-key` | Cookie (insider) | Rotate insider key |
+| POST | `/api/util/share-for` | Cookie or `?key=` | Audience-aware share link generation |
 | POST | `/event` | `?key=` (scoped) | Webhook gateway |
 | GET | `/health` | None | Health check |
+
+## Utility Endpoints (`/api/util/*`)
+
+Programmatic endpoints for access decisions and server introspection. Used by the resident AI assistant and future CLI.
+
+### `POST /api/util/share-for`
+
+Determines the appropriate link type for sharing a resource with a specific audience. The sharer is identified from the request's auth context.
+
+**Request:**
+```json
+{
+  "path": "/d/projects/foo/spec.md",
+  "insiders": ["devin@qtalo.com", "guest@example.com"],
+  "depth": 2,
+  "dirs": false,
+  "enforceOutsiderPolicy": true
+}
+```
+
+**Decision tree:**
+1. Can the sharer access this path? No → `null`
+2. Can all insider participants access this path? No → `null` (returns `blocked` list)
+3. Are there non-insider participants?
+   - No → bare insider URL
+   - Yes + `enforceOutsiderPolicy` + policy allows → outsider share link
+   - Yes + `enforceOutsiderPolicy` + policy denies → `null`
+   - Yes + policy not enforced → outsider share link (+ `warning` if policy would deny)
+
+**Response types:** `insider`, `outsider-share`, `blocked`, `policy-denied`
+
+### Outsider Policy
+
+Global config constraining which paths are eligible for outsider sharing:
+
+```typescript
+outsiderPolicy?: {
+  allow?: string[];
+  deny?: string[];
+}
+```
+
+Uses the same allow/deny scopes model as insider scopes. When `enforceOutsiderPolicy: true` is passed (default for AI assistant usage), the policy gates outsider share link generation. When `false` (web UI usage), the policy produces warnings but doesn't block.
+
+### Client-side Insider Upgrade
+
+When a logged-in insider lands on an outsider share link, the SPA detects insider status via `/api/auth/status` and strips the key/depth/stack params, upgrading to full insider navigation.
+
+### Future Utility Endpoints (planned)
+
+| Path | Description |
+|------|-------------|
+| `/api/util/access` | Raw access check for a single identity + path |
+| `/api/util/keys` | Key derivation and rotation status |
+| `/api/util/config` | Sanitized config introspection |
+| `/api/util/health` | Extended health check |
 
 ## Build & Development
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -118,6 +118,7 @@ export function loadConfig(): RuntimeConfig {
     chromePath: config.chromePath,
     roots: config.roots,
     mermaidCliPath: config.mermaidCliPath,
+    outsiderPolicy: normalizeScopes(config.outsiderPolicy) ?? null,
     events: config.events,
     authModes: config.auth.modes,
     resolvedKeys,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -88,6 +88,12 @@ export const jeevesConfigSchema = z
     roots: z.record(z.string(), z.string()).optional(),
     /** Path to mermaid-cli (npx prefix directory). If not set, mermaid rendering is disabled. */
     mermaidCliPath: z.string().optional(),
+    /**
+     * Global outsider policy — constrains which paths are eligible for outsider sharing.
+     * Uses the same allow/deny model as insider scopes.
+     * If omitted, all paths are shareable with outsiders.
+     */
+    outsiderPolicy: scopesObjectSchema.optional(),
   })
   .superRefine((config, ctx) => {
     // Google auth mode requires google config + sessionSecret

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -53,6 +53,7 @@ export interface RuntimeConfig {
   chromePath: string;
   roots?: Record<string, string>;
   mermaidCliPath?: string;
+  outsiderPolicy: NormalizedScopes | null;
   events: JeevesConfig['events'];
   authModes: AuthMode[];
   resolvedKeys: ResolvedKey[];

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -11,7 +11,7 @@ import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 
 import { _pathMatchesScopes, verifyKey } from '../auth/keys.js';
 import archiver from 'archiver';
-import { computeDeepShareKey, computeOutsiderKeyWithExpiry, computePathKey } from '../util/crypto.js';
+import { computeDeepShareKey, computeInsiderKey, computeOutsiderKeyWithExpiry, computePathKey, timingSafeEqual } from '../util/crypto.js';
 import { COOKIE_NAME, verifySessionCookie } from '../auth/session.js';
 import { getConfig, resetConfig } from '../config/index.js';
 import { setInsiderKey } from '../util/state.js';
@@ -73,6 +73,61 @@ export const apiRoute: FastifyPluginAsync = async (fastify) => {
     if (!request.url.startsWith('/api')) return;
     if (request.url.startsWith('/api/readme-link')) return;
     if (request.url.startsWith('/api/auth/status')) return;
+    // Utility endpoints handle their own scope checking (path is in body, not URL)
+    if (request.url.startsWith('/api/util/')) {
+      // Still need auth, but skip scope-based path verification
+      const config = getConfig();
+      const query = request.query as { key?: string; exp?: string };
+      const provided = query.key;
+
+      // Try key auth (insider key, no path scope check)
+      if (provided) {
+        const result = verifyKey(config.resolvedKeys, '/', provided, query.exp, config.resolvedInsiders);
+        if (result.valid && result.mode === 'insider') {
+          (request as { accessMode?: AccessMode }).accessMode = 'insider';
+          (request as { authSeed?: string }).authSeed = result.seed!;
+          (request as { insiderScopes?: NormalizedScopes | null }).insiderScopes =
+            config.resolvedKeys.find(k => k.seed === result.seed)?.scopes ?? null;
+          return;
+        }
+        // Check insider keys
+        for (const ri of config.resolvedInsiders) {
+          if (!ri.seed) continue;
+          const insiderKey = computeInsiderKey(ri.seed);
+          if (timingSafeEqual(provided, insiderKey)) {
+            (request as { accessMode?: AccessMode }).accessMode = 'insider';
+            (request as { authSeed?: string }).authSeed = ri.seed;
+            (request as { insiderScopes?: NormalizedScopes | null }).insiderScopes = ri.scopes;
+            (request as { insiderEmail?: string }).insiderEmail = ri.email;
+            return;
+          }
+        }
+      }
+
+      // Try session auth
+      const sessionSecret = config.sessionSecret;
+      if (sessionSecret) {
+        const cookieValue = (request.cookies as Record<string, string> | undefined)?.[COOKIE_NAME];
+        if (cookieValue) {
+          const session = verifySessionCookie(cookieValue, sessionSecret);
+          if (session) {
+            const insider = config.resolvedInsiders.find(
+              (i) => i.email.toLowerCase() === session.email.toLowerCase(),
+            );
+            if (insider?.seed) {
+              (request as { accessMode?: AccessMode }).accessMode = 'insider';
+              (request as { authSeed?: string }).authSeed = insider.seed;
+              (request as { insiderScopes?: NormalizedScopes | null }).insiderScopes = insider.scopes;
+              (request as { insiderEmail?: string }).insiderEmail = insider.email;
+              return;
+            }
+          }
+        }
+      }
+
+      reply.code(401).send({ error: 'Insider auth required for utility endpoints' });
+      return;
+    }
 
     const config = getConfig();
     const query = request.query as { key?: string; exp?: string; d?: string; dirs?: string; s?: string };
@@ -809,6 +864,131 @@ export const apiRoute: FastifyPluginAsync = async (fastify) => {
         ok: true,
         keyCreatedAt: now,
       });
+    },
+  );
+
+  // POST /api/util/share-for — audience-aware share link generation
+  fastify.post<{
+    Body: {
+      path: string;
+      insiders: string[];
+      depth?: number;
+      dirs?: boolean;
+      enforceOutsiderPolicy?: boolean;
+    };
+  }>(
+    '/api/util/share-for',
+    async (request, reply) => {
+      const config = getConfig();
+
+      // 1. Identify sharer from auth context
+      const sharerSeed = (request as { authSeed?: string }).authSeed;
+      const sharerScopes = (request as { insiderScopes?: NormalizedScopes | null }).insiderScopes ?? null;
+      if (!sharerSeed) {
+        return reply.code(401).send({ error: 'Authentication required' });
+      }
+
+      const { path: targetPath, insiders: audienceIds, depth, dirs, enforceOutsiderPolicy } = request.body;
+      if (!targetPath) return reply.code(400).send({ error: 'path is required' });
+      if (!audienceIds || !Array.isArray(audienceIds)) return reply.code(400).send({ error: 'insiders array is required' });
+
+      // 2. Can the sharer access this path?
+      if (sharerScopes && !_pathMatchesScopes(targetPath, sharerScopes)) {
+        return reply.send({
+          url: null,
+          type: 'blocked',
+          reason: 'Sharer does not have access to this path',
+          blocked: [],
+        });
+      }
+
+      // 3. Check each audience member
+      const blockedInsiders: string[] = [];
+      const unknownIds: string[] = []; // Not found in insiders map → outsiders
+
+      for (const id of audienceIds) {
+        const insider = config.resolvedInsiders.find(
+          (ri) => ri.email.toLowerCase() === id.toLowerCase(),
+        );
+        if (!insider || !insider.seed) {
+          unknownIds.push(id);
+          continue;
+        }
+        // Insider exists — check their scopes against the path
+        if (insider.scopes && !_pathMatchesScopes(targetPath, insider.scopes)) {
+          blockedInsiders.push(id);
+        }
+      }
+
+      // If any insider is blocked, return null
+      if (blockedInsiders.length > 0) {
+        return reply.send({
+          url: null,
+          type: 'blocked',
+          reason: `Insider(s) do not have access to this path`,
+          blocked: blockedInsiders,
+        });
+      }
+
+      // 4. Determine link type
+      const hasOutsiders = unknownIds.length > 0;
+
+      if (!hasOutsiders) {
+        // All audience members are insiders with access → bare insider URL
+        const proto = request.headers['x-forwarded-proto'] || 'https';
+        const host = request.headers['x-forwarded-host'] || request.headers.host;
+        return reply.send({
+          url: `${proto}://${host}/browse${targetPath}`,
+          type: 'insider',
+        });
+      }
+
+      // Has outsiders — check outsider policy
+      const outsiderPolicy = config.outsiderPolicy;
+      const policyEnforced = enforceOutsiderPolicy !== false; // default true
+
+      if (outsiderPolicy && policyEnforced) {
+        if (!_pathMatchesScopes(targetPath, outsiderPolicy)) {
+          return reply.send({
+            url: null,
+            type: 'policy-denied',
+            reason: 'Outsider policy does not allow sharing this path',
+          });
+        }
+      }
+
+      // Generate outsider share link
+      const { encodeStack } = await import('../services/deepShareLinks.js');
+
+      const shareDepth = depth ?? 0;
+      const shareDirs = dirs ?? false;
+      const stack = encodeStack([targetPath]);
+      const deepParams: import('../util/crypto.js').DeepShareParams = {
+        depth: shareDepth,
+        dirs: shareDirs,
+        stack,
+      };
+
+      const outsiderKey = computeDeepShareKey(sharerSeed, targetPath, deepParams);
+      const proto = request.headers['x-forwarded-proto'] || 'https';
+      const host = request.headers['x-forwarded-host'] || request.headers.host;
+
+      let shareUrl = `${proto}://${host}/browse${targetPath}?key=${outsiderKey}`;
+      if (shareDepth > 0) shareUrl += `&d=${shareDepth}`;
+      shareUrl += `&dirs=${shareDirs ? 1 : 0}`;
+      if (stack) shareUrl += `&s=${stack}`;
+
+      const response: Record<string, unknown> = {
+        url: shareUrl,
+        type: 'outsider-share',
+      };
+
+      // Add warning if policy would deny but wasn't enforced
+      if (outsiderPolicy && !policyEnforced && !_pathMatchesScopes(targetPath, outsiderPolicy)) {
+        response.warning = 'Outsider policy would deny this path';
+      }
+
+      return reply.send(response);
     },
   );
 


### PR DESCRIPTION
## Summary

Adds utility API endpoints under `/api/util/*` and a global outsider policy, starting with `POST /api/util/share-for` — an audience-aware share link generator.

## Changes

### `POST /api/util/share-for`
Given a file path and list of audience identifiers, returns the appropriate share link:
- **All insiders with access** → bare insider URL
- **Mixed audience** → outsider share link (with depth/dirs)
- **Blocked insider** → `null` + blocked list
- **Outsider policy denied** → `null`
- **Policy not enforced** → outsider share link + warning

Sharer identity derived from auth context (key or session).

### `outsiderPolicy` config option
```typescript
outsiderPolicy: {
  allow: ['/d/projects/*', '/d/docs/*'],
  deny: ['/d/secrets/*'],
}
```
Global constraint on what paths are eligible for outsider sharing. Uses same allow/deny model as insider scopes. Enforced when `enforceOutsiderPolicy: true` (default).

### `/api/util/*` auth handling
Utility endpoints require insider-level auth but skip path-based scope checks (since the target path is in the request body, not the URL). Scope checking happens inside the endpoint logic.

### Requirements doc
Updated with full utility endpoints spec, outsider policy design, client-side insider upgrade (planned), and future endpoint table.

## Testing
- New endpoint tested: all-insiders → insider link, mixed-audience → outsider-share
- All 29 existing deep-share tests pass
- Dev server running at `dev.jeeves.johngalt.id` for live review

Closes #16
