### PR TITLE
fix: forward auth params on downloads, show error popup

### DIFF
--- a/client/src/components/DownloadDropdown.tsx
+++ b/client/src/components/DownloadDropdown.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { withKey } from '@/lib/api';
 
 interface DownloadDropdownProps {
   /** Current file path (relative, no leading slash) */
@@ -57,8 +58,11 @@ function getDownloadItems(reqPath: string, file: { fileName: string; type: strin
 }
 
 async function downloadBlob(href: string, filename: string) {
-  const res = await fetch(href, { credentials: 'include' });
-  if (!res.ok) throw new Error(`Download failed (${String(res.status)})`);
+  const res = await fetch(withKey(href), { credentials: 'include' });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(body || `Download failed (${String(res.status)})`);
+  }
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -94,6 +98,8 @@ export function DownloadDropdown({ reqPath, file, isDirectory, compact, variant 
       setErrorMsg(msg);
       updateState('error');
       onError?.(msg);
+      // Show error immediately — don't hide it inside the closed dropdown
+      alert(`Download failed: ${msg}`);
     }
   };
 


### PR DESCRIPTION
**Bug:** Downloads from outsider share links returned 401 because \downloadBlob\ didn't forward key/d/dirs/s auth params.

**Fix:** Use \withKey()\ in \downloadBlob\ to forward all auth params. Also show \lert()\ on failure instead of hiding the error inside the closed dropdown.

**Root cause:** The \etch()\ call in \downloadBlob\ used the bare href without auth params. Insider downloads worked (session cookie), outsider downloads failed (no key forwarded).