### PR TITLE
refactor: Copy Raw Link uses /api/raw/ directly

### DIFF
--- a/client/src/components/LinkDropdown.tsx
+++ b/client/src/components/LinkDropdown.tsx
@@ -57,7 +57,11 @@ async function copyShareLink(path: string, settings: ShareSettings, type: LinkTy
 
   let fullUrl = window.location.origin + data.url;
   if (type === 'raw') {
-    fullUrl += (fullUrl.includes('?') ? '&' : '?') + 'raw=1';
+    // Build /api/raw/ URL directly with auth params from the share link
+    const shareUrl = new URL(fullUrl);
+    const rawPath = shareUrl.pathname.replace('/browse/', '/api/raw/');
+    shareUrl.pathname = rawPath;
+    fullUrl = shareUrl.toString();
   } else if (type === 'event') {
     fullUrl = window.location.origin + '/event?key=' + data.url.split('key=')[1];
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,15 +87,7 @@ async function start() {
       fastify.get('/browse', async (_request, reply) => {
         return reply.sendFile('index.html', clientDir);
       });
-      fastify.get<{ Params: { '*': string }; Querystring: { raw?: string } }>('/browse/*', async (request, reply) => {
-        // raw=1 → serve raw file bytes instead of the SPA
-        if (request.query.raw === '1') {
-          const filePath = request.params['*'];
-          const qs = new URLSearchParams(request.query as Record<string, string>);
-          qs.delete('raw');
-          const suffix = qs.toString() ? `?${qs.toString()}` : '';
-          return reply.redirect(`/api/raw/${filePath}${suffix}`);
-        }
+      fastify.get('/browse/*', async (_request, reply) => {
         return reply.sendFile('index.html', clientDir);
       });
     }


### PR DESCRIPTION
Copy Raw Link now builds the \/api/raw/\ URL directly with auth params, instead of appending \?raw=1\ to a \/browse/\ URL. Removes the server-side raw=1 redirect (no longer needed).