### PR TITLE
fix: case-insensitive email matching for insiders

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -94,10 +94,11 @@ export function loadConfig(): RuntimeConfig {
   const resolvedInsiders: ResolvedInsider[] = Object.entries(
     config.insiders as Record<string, InsiderEntry>,
   ).map((
-    [email, entry]: [string, InsiderEntry],
+    [rawEmail, entry]: [string, InsiderEntry],
   ) => {
+      const email = rawEmail.toLowerCase();
       const scopes = normalizeScopes(entry.scopes);
-      const stateKey = serverState.insiderKeys?.[email.toLowerCase()];
+      const stateKey = serverState.insiderKeys?.[email];
       return {
         email,
         seed: stateKey?.seed ?? '',


### PR DESCRIPTION
Normalizes insider emails to lowercase at config load time. All comparison points already used .toLowerCase() on both sides; this makes the config source consistent with state.json (which already lowercases).