### PR TITLE
fix: client TS errors + picomatch dot matching

### DIFF
--- a/client/src/components/DirectoryRow.tsx
+++ b/client/src/components/DirectoryRow.tsx
@@ -5,13 +5,6 @@ import { DownloadDropdown } from '@/components/DownloadDropdown';
 import { LinkDropdown } from '@/components/LinkDropdown';
 import type { DirectoryEntry, ShareSettings } from '@/lib/api';
 
-/** Extensions that render a page view */
-const PAGE_EXTENSIONS = new Set([
-  '.md', '.svg', '.txt', '.json', '.yaml', '.yml', '.html', '.css', '.js', '.ts',
-  '.xml', '.csv', '.jsonl', '.log', '.mmd', '.ps1', '.bat', '.cmd', '.sh', '.py',
-  '.rb', '.go', '.rs', '.java', '.c', '.cpp', '.h', '.hpp',
-]);
-
 function formatSize(bytes: number | null): string {
   if (bytes === null) return '-';
   if (bytes === 0) return '0 B';

--- a/client/src/components/FileContentView.tsx
+++ b/client/src/components/FileContentView.tsx
@@ -35,7 +35,7 @@ export function FileContentView({
   editing, setEditing,
   proseWidth, topBarHeight, mainRef,
   mobileTocOpen, setMobileTocOpen,
-  onSave, loading,
+  onSave, loading: _loading,
 }: FileContentViewProps) {
   const renderable = file ? isRenderable(file) : false;
   const activeTab = renderable ? viewTab : 'raw';

--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -141,7 +141,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
   const [dateTo, setDateTo] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
     if (open) {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -57,7 +57,7 @@ export interface DriveEntry {
 }
 
 export interface FileContent {
-  type: 'markdown' | 'text' | 'svg' | 'mermaid' | 'image' | 'binary';
+  type: 'markdown' | 'text' | 'svg' | 'mermaid' | 'plantuml' | 'image' | 'binary';
   content?: string;
   html?: string;
   headings?: { level: number; text: string; slug: string }[];

--- a/client/src/pages/FileBrowser.tsx
+++ b/client/src/pages/FileBrowser.tsx
@@ -8,7 +8,7 @@ import { DriveList } from '@/components/DriveList';
 import { FileContentView } from '@/components/FileContentView';
 import { Header } from '@/components/layout/Header';
 import { LinkDropdown } from '@/components/LinkDropdown';
-import { TabBar, isRenderableExt } from '@/components/TabBar';
+import { TabBar } from '@/components/TabBar';
 import { useFileBrowser } from '@/hooks/useFileBrowser';
 
 export function FileBrowser() {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@/lib/theme';
 export function Home() {
   const { loading, authenticated } = useAuth();
   const navigate = useNavigate();
-  const [theme] = useTheme();
+  const [_theme] = useTheme();
 
   useEffect(() => {
     if (!loading && authenticated) {

--- a/src/auth/keys.ts
+++ b/src/auth/keys.ts
@@ -37,6 +37,7 @@ function pathMatchesPatterns(requestPath: string, patterns: string[]): boolean {
   const normalized = requestPath.toLowerCase().replace(/\/+$/, '');
   const isMatch = picomatch(
     patterns.map((p) => p.toLowerCase().replace(/\/+$/, '')),
+    { dot: true },
   );
   return isMatch(normalized);
 }


### PR DESCRIPTION
- Add `plantuml` to `FileContent` type union (was missing, caused TS2367)
- Remove unused imports/variables (`PAGE_EXTENSIONS`, `isRenderableExt`, `loading`, `theme`)
- Fix `useRef` requiring initial value for React 19 / `@types/react` 19
- Enable `dot:true` in picomatch for path scope matching (patterns like `/**` now match dot-segments like `.domain`)

All five `stan run` checks pass: typecheck, lint, test, build, knip.