### PR TITLE
fix: event queue byte/char cursor mismatch + postbuild client

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev": "tsx watch src/server.ts",
     "prebuild": "node -e \"const fs=require('fs');['dist','.tsbuildinfo'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\"",
     "build": "tsc",
+    "postbuild": "cd client && npm run build",
     "typecheck": "cross-env NODE_OPTIONS=--max-old-space-size=4096 tsc --noEmit",
     "lint": "node -e \"require('fs').mkdirSync('dist',{recursive:true})\" && eslint .",
     "lint:fix": "node -e \"require('fs').mkdirSync('dist',{recursive:true})\" && eslint --fix .",

--- a/src/services/eventQueue.ts
+++ b/src/services/eventQueue.ts
@@ -87,16 +87,16 @@ function readEntriesFromCursor(): {
   }
 
   const cursor = readCursor();
-  const content = fs.readFileSync(eventQueuePath, 'utf8');
+  const buf = fs.readFileSync(eventQueuePath);
 
-  // Read from cursor position
-  const remaining = content.slice(cursor);
+  // Read from cursor position (byte-based to match writeCursor)
+  const remaining = buf.subarray(cursor).toString('utf8');
   const lines = remaining
     .split('\n')
     .filter((line) => line.trim())
     .map((line) => JSON.parse(line) as QueueEntry);
 
-  const newPosition = Buffer.byteLength(content, 'utf8');
+  const newPosition = buf.length;
 
   return { entries: lines, newPosition };
 }


### PR DESCRIPTION
Two fixes:

1. **Event queue cursor mismatch** — \eadEntriesFromCursor\ was reading the file as UTF-8 string and using \content.slice(cursor)\ (character offset), but the cursor was written via \Buffer.byteLength\ (byte offset). Non-ASCII characters in Jira webhook payloads caused the slice to land mid-line, crashing the server on startup with \SyntaxError: Unexpected token\. Fix: read as Buffer, slice by bytes.

2. **Postbuild client** — Added \postbuild\ script so \
pm run build\ always rebuilds the client SPA after the server. Previously, \prebuild\ nuked \dist/\ (including \dist/client/\), and the server build alone didn't restore it, causing \/browse\ 404s.

All five \stan run\ checks pass.