### PR TITLE
chore: add default port 1934

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -71,7 +71,7 @@ export const keyEntrySchema = z.union([
 /** Top-level Jeeves Server configuration */
 export const jeevesConfigSchema = z
   .object({
-    port: z.number().int().positive(),
+    port: z.number().int().positive().default(1934),
     chromePath: z.string().min(1),
     auth: authSchema,
     insiders: z.record(z.email(), insiderEntrySchema).default({}),


### PR DESCRIPTION
Part of the 1930s port namespace migration.

| Service | Port |
|---------|------|
| jeeves-server | 1934 |
| jeeves-watcher | 1936 |
| jeeves-runner | 1937 |

Port was required with no default. Now defaults to 1934.
Tests: 71/71 pass.