### PR TITLE
fix: exit edit mode after save

### DIFF
--- a/client/src/hooks/useFileData.ts
+++ b/client/src/hooks/useFileData.ts
@@ -58,6 +58,7 @@ export function useFileData(reqPath: string, searchParams: URLSearchParams) {
     const refreshed = await getFileRaw(reqPath);
     setFileRaw(refreshed);
     try { const r = await getFile(reqPath); setFileRendered(r); } catch { /* ignore */ }
+    setEditing(false);
   };
 
   return {


### PR DESCRIPTION
Adds \setEditing(false)\ after successful save in \useFileData.ts\. Previous PR #62 was reused for the port default change; this is the actual fix.