### PR TITLE
feat: align search browse filter with watcher domains convention

### DIFF
--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -77,9 +77,9 @@ function ResultRow({ result, onNavigate }: { result: SearchResult; onNavigate: (
             >
               {result.fileName}
             </button>
-            {result.domain && (
+            {result.domains && result.domains.length > 0 && (
               <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border">
-                {result.domain}
+                {result.domains.join(', ')}
               </span>
             )}
             <span className="text-[10px] text-muted-foreground shrink-0">
@@ -224,7 +224,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
 
   // Apply client-side filters
   const filtered = results.filter((r) => {
-    if (domainFilter.size > 0 && (!r.domain || !domainFilter.has(r.domain))) return false;
+    if (domainFilter.size > 0 && (!r.domains || !r.domains.some(d => domainFilter.has(d)))) return false;
     if (authorFilter.size > 0 && (!r.author || !authorFilter.has(r.author))) return false;
     if (extFilter.size > 0) {
       const dot = r.fileName.lastIndexOf('.');
@@ -363,3 +363,4 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
     </div>
   );
 }
+

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -185,7 +185,7 @@ export interface SearchResult {
   fileName: string;
   bestScore: number;
   mtime?: string;
-  domain?: string;
+  domains?: string[];
   title?: string;
   author?: string;
   participants?: string;
@@ -221,3 +221,4 @@ export async function clearCache(path: string): Promise<{ cleared: { exports: nu
     { method: 'DELETE' },
   );
 }
+

--- a/src/routes/api/search.ts
+++ b/src/routes/api/search.ts
@@ -42,7 +42,7 @@ interface WatcherResult {
     chunk_text?: string;
     chunk_index?: number;
     total_chunks?: number;
-    domain?: string;
+    domains?: string[];
     title?: string;
     author?: string;
     participants?: string;
@@ -57,7 +57,7 @@ interface GroupedResult {
   fileName: string;
   bestScore: number;
   mtime?: string;
-  domain?: string;
+  domains?: string[];
   title?: string;
   author?: string;
   participants?: string;
@@ -198,7 +198,7 @@ export const searchRoutes: FastifyPluginAsync = async (fastify) => {
             browsePath: key,
             fileName: parts[parts.length - 1],
             bestScore: r.score,
-            domain: r.payload.domain,
+            domains: Array.isArray(r.payload.domains) ? (r.payload.domains as string[]) : (r.payload.domain ? [r.payload.domain as string] : []),
             title: r.payload.title,
             author: r.payload.author,
             participants: r.payload.participants,
@@ -206,8 +206,8 @@ export const searchRoutes: FastifyPluginAsync = async (fastify) => {
           };
           fileMap.set(key, group);
         }
-        if (r.score > group.bestScore) group.bestScore = r.score;
-        group.chunks.push({
+        if (r.score > group!.bestScore) group!.bestScore = r.score;
+        group!.chunks.push({
           text: r.payload.chunk_text ?? '',
           index: r.payload.chunk_index ?? 0,
           score: r.score,
@@ -237,7 +237,7 @@ export const searchRoutes: FastifyPluginAsync = async (fastify) => {
 
       // Extract distinct metadata values for filter chips
       const metadata = {
-        domains: [...new Set(grouped.map((g) => g.domain).filter(Boolean))],
+        domains: [...new Set(grouped.flatMap((g) => g.domains || []).filter(Boolean))],
         authors: [...new Set(grouped.map((g) => g.author).filter(Boolean))],
         participants: [
           ...new Set(
@@ -261,3 +261,6 @@ export const searchRoutes: FastifyPluginAsync = async (fastify) => {
     }
   });
 };
+
+
+


### PR DESCRIPTION
Updates the Browse/Search dialog metadata parsing to support domains as a string array, aligning with jeeves-watcher v0.7.0 domains convention. Maintains backward compatibility with domain for legacy points.