### PR TITLE
Phase 2, Step 8: Scroll anchoring

### DIFF
--- a/packages/service/client/src/components/MarkdownView.tsx
+++ b/packages/service/client/src/components/MarkdownView.tsx
@@ -1,7 +1,9 @@
 /**
  * Markdown rendered view with TOC sidebar.
  */
+import { useRef } from 'react';
 import type { FileContent } from '@/lib/api';
+import { useScrollAnchor } from '@/hooks/useScrollAnchor';
 import { initEmbeddedDiagramPanzoom } from '@/components/EmbeddedDiagramPanzoom';
 import { initLazyDiagrams } from '@/components/LazyDiagram';
 import { initInlineSvgPanzoom } from '@/components/InlineSvgPanzoom';
@@ -60,6 +62,8 @@ export function MarkdownView({
   mobileTocOpen, setMobileTocOpen,
 }: MarkdownViewProps) {
   const [theme] = useTheme();
+  const articleRef = useRef<HTMLElement>(null);
+  useScrollAnchor(mainRef, articleRef);
   const plainCode = new URLSearchParams(window.location.search).has('plain_code');
   const hasHeadings = fileRendered.headings && fileRendered.headings.length > 2;
 
@@ -116,7 +120,7 @@ export function MarkdownView({
 
         {/* Markdown article */}
         <article
-          ref={(el) => { if (el) { if (!plainCode) initCodeBlockCm6(el, theme); injectCopyButtons(el); initInlineSvgPanzoom(el); initEmbeddedDiagramPanzoom(el); initLazyDiagrams(el); } }}
+          ref={(el) => { (articleRef as React.MutableRefObject<HTMLElement | null>).current = el; if (el) { if (!plainCode) initCodeBlockCm6(el, theme); injectCopyButtons(el); initInlineSvgPanzoom(el); initEmbeddedDiagramPanzoom(el); initLazyDiagrams(el); } }}
           className={`prose bg-background p-6 rounded-lg border border-border min-w-0 flex-1 ${
             proseWidth === 'narrow' ? 'max-w-prose' : proseWidth === 'medium' ? 'max-w-5xl' : 'max-w-none'
           }`}

--- a/packages/service/client/src/hooks/useScrollAnchor.ts
+++ b/packages/service/client/src/hooks/useScrollAnchor.ts
@@ -1,0 +1,68 @@
+/**
+ * Scroll anchoring hook.
+ *
+ * Observes a scrollable container for content height changes (e.g. lazy diagram
+ * renders replacing placeholders with SVGs). When content above the current
+ * viewport grows, compensates the scroll position so the user's reading position
+ * remains stable.
+ *
+ * Uses ResizeObserver on the content element inside the scroll container.
+ */
+import { useEffect, useRef } from 'react';
+
+/**
+ * Attach scroll anchoring to a scrollable container.
+ *
+ * @param scrollRef - Ref to the scrollable container (the element with overflow-y).
+ * @param contentRef - Ref to the content element inside the scroller whose height may change.
+ * @param active - Whether anchoring is active (disable during programmatic scrolls).
+ */
+export function useScrollAnchor(
+  scrollRef: React.RefObject<HTMLElement | null>,
+  contentRef: React.RefObject<HTMLElement | null>,
+  active = true,
+): void {
+  const prevHeight = useRef<number>(0);
+  const prevScrollTop = useRef<number>(0);
+
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    const content = contentRef.current;
+    if (!scroller || !content || !active) return;
+
+    // Snapshot initial state
+    prevHeight.current = content.scrollHeight;
+    prevScrollTop.current = scroller.scrollTop;
+
+    // Track scroll position
+    const onScroll = () => {
+      prevScrollTop.current = scroller.scrollTop;
+    };
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+
+    // Observe content size changes
+    const observer = new ResizeObserver(() => {
+      const newHeight = content.scrollHeight;
+      const oldHeight = prevHeight.current;
+      const delta = newHeight - oldHeight;
+
+      if (delta > 0 && prevScrollTop.current > 0) {
+        // Content grew — check if the growth happened above the viewport
+        // by comparing the new scroll position needed to keep the same content visible.
+        // If the scroller's scrollTop hasn't changed but content height grew,
+        // the growth was above or at the current position.
+        scroller.scrollTop = prevScrollTop.current + delta;
+        prevScrollTop.current = scroller.scrollTop;
+      }
+
+      prevHeight.current = newHeight;
+    });
+
+    observer.observe(content);
+
+    return () => {
+      scroller.removeEventListener('scroll', onScroll);
+      observer.disconnect();
+    };
+  }, [scrollRef, contentRef, active]);
+}


### PR DESCRIPTION
Client-only change. Adds ResizeObserver-based scroll compensation when lazy diagrams render above the viewport. Fixes content shifting and deep-link drift.