### PR TITLE
fix: resetConfig should reload, not clear

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -302,6 +303,7 @@
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -2497,6 +2499,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2594,6 +2597,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -5036,6 +5040,7 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -5060,6 +5065,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5070,6 +5076,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5163,6 +5170,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -5751,6 +5759,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6456,6 +6465,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6711,6 +6721,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -7009,6 +7020,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -7261,6 +7273,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7670,6 +7683,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7929,7 +7943,8 @@
       "version": "0.0.1367902",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -8297,6 +8312,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8357,6 +8373,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10265,6 +10282,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -11409,6 +11427,7 @@
       "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz",
       "integrity": "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.1",
@@ -12384,6 +12403,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12568,6 +12588,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12699,6 +12720,7 @@
       "deprecated": "< 24.15.0 is no longer supported",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.6.1",
         "chromium-bidi": "0.11.0",
@@ -12792,6 +12814,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12801,6 +12824,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13276,6 +13300,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -13898,7 +13923,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -14128,7 +14154,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -14136,6 +14163,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14188,6 +14216,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14434,6 +14463,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14509,6 +14539,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -15088,6 +15119,7 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15237,6 +15269,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -15256,7 +15289,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-server-openclaw",
-      "version": "0.1.0",
+      "version": "0.1.0-0",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-server-openclaw": "dist/cli.js"
@@ -15277,7 +15310,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-server",
-      "version": "2.9.3",
+      "version": "3.0.0-0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/service/src/config/index.ts
+++ b/packages/service/src/config/index.ts
@@ -75,6 +75,7 @@ export async function loadConfig(configPath?: string): Promise<RuntimeConfig> {
 }
 
 let configInstance: RuntimeConfig | null = null;
+let lastConfigPath: string | undefined;
 
 /**
  * Check if the config singleton has been initialized.
@@ -101,13 +102,22 @@ export function getConfig(): RuntimeConfig {
  * @param configPath - Optional explicit path to a config file.
  */
 export async function initConfig(configPath?: string): Promise<RuntimeConfig> {
+  lastConfigPath = configPath;
   configInstance = await loadConfig(configPath);
   return configInstance;
 }
 
 /**
- * Reset the config singleton (for testing).
+ * Reload the config singleton from the last-used config path.
+ * Call after mutating state that affects resolved config (e.g., key rotation).
  */
-export function resetConfig(): void {
+export async function resetConfig(): Promise<void> {
+  configInstance = await loadConfig(lastConfigPath);
+}
+
+/**
+ * Clear the config singleton (for testing only).
+ */
+export function clearConfig(): void {
   configInstance = null;
 }

--- a/packages/service/src/config/loadConfig.test.ts
+++ b/packages/service/src/config/loadConfig.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { getConfig, initConfig, loadConfig, resetConfig } from './index.js';
+import { clearConfig, getConfig, initConfig, loadConfig } from './index.js';
 
 const VALID_CONFIG = {
   port: 9999,
@@ -28,12 +28,12 @@ describe('loadConfig', () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-config-'));
-    resetConfig();
+    clearConfig();
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    resetConfig();
+    clearConfig();
   });
 
   it('loads a valid JSON config file', async () => {
@@ -127,12 +127,12 @@ describe('config singleton', () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-config-'));
-    resetConfig();
+    clearConfig();
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    resetConfig();
+    clearConfig();
   });
 
   it('throws if getConfig called before initConfig', () => {
@@ -146,10 +146,10 @@ describe('config singleton', () => {
     expect(config.port).toBe(9999);
   });
 
-  it('resetConfig clears the singleton', async () => {
+  it('clearConfig clears the singleton', async () => {
     const configPath = writeConfig(tmpDir, VALID_CONFIG);
     await initConfig(configPath);
-    resetConfig();
+    clearConfig();
     expect(() => getConfig()).toThrow('Config not initialized');
   });
 });

--- a/packages/service/src/routes/api/sharing.ts
+++ b/packages/service/src/routes/api/sharing.ts
@@ -132,7 +132,7 @@ export const sharingRoutes: FastifyPluginAsync = async (fastify) => {
     const newSeed = crypto.randomBytes(32).toString('hex');
     const now = new Date().toISOString();
     setInsiderKey(insider.email, newSeed, now);
-    resetConfig();
+    await resetConfig();
 
     return reply.send({ ok: true, keyCreatedAt: now });
   });

--- a/packages/service/src/routes/auth.ts
+++ b/packages/service/src/routes/auth.ts
@@ -108,7 +108,7 @@ export const authRoute: FastifyPluginAsync = async (fastify) => {
 
       // Persist to state.json (mutable runtime state)
       setInsiderKey(insider.email, newSeed, timestamp);
-      resetConfig(); // Reload to pick up new state
+      await resetConfig(); // Reload to pick up new state
     }
 
     // Set session cookie

--- a/packages/service/src/routes/keys.ts
+++ b/packages/service/src/routes/keys.ts
@@ -86,7 +86,7 @@ export const keysRoute: FastifyPluginAsync = async (fastify) => {
         const insiderResult = resolveInsiderKeyAuth(config, provided);
         if (insiderResult.valid && insiderResult.email) {
           // Insider key rotation
-          return rotateInsiderSeed(insiderResult.email, config);
+          return await rotateInsiderSeed(insiderResult.email, config);
         }
 
         // Machine key rotation is not supported with TS config
@@ -105,7 +105,7 @@ export const keysRoute: FastifyPluginAsync = async (fastify) => {
       // Try session-based auth
       const sessionResult = resolveSessionAuth(config, request);
       if (sessionResult.valid && sessionResult.email) {
-        return rotateInsiderSeed(sessionResult.email, config);
+        return await rotateInsiderSeed(sessionResult.email, config);
       }
 
       return reply.code(401).send({ error: 'Invalid insider key' });
@@ -149,7 +149,7 @@ export const keysRoute: FastifyPluginAsync = async (fastify) => {
   );
 };
 
-function rotateInsiderSeed(
+async function rotateInsiderSeed(
   email: string,
   config: ReturnType<typeof getConfig>,
 ) {
@@ -166,7 +166,7 @@ function rotateInsiderSeed(
     at: timestamp,
   });
   setKeyRotationTimestamp(timestamp);
-  resetConfig();
+  await resetConfig();
 
   return { ok: true, keyName: insider.email };
 }


### PR DESCRIPTION
Fixes the dev server crash ('Config not initialized. Call initConfig() before getConfig()').

Root cause: routes call resetConfig() after key rotation/login to force a reload, but resetConfig() was implemented as configInstance = null. Next request hits getConfig() and throws.

Changes:
- resetConfig() is now async and reloads config from the last-used config path
- Added clearConfig() for test-only clearing
- Updated routes to await resetConfig()
- Updated config tests accordingly

Verified: typecheck OK, lint OK, tests OK, build OK