### PR TITLE
fix: plugin auth chain and status endpoint improvements

### DIFF
--- a/packages/openclaw/skills/jeeves-server/SKILL.md
+++ b/packages/openclaw/skills/jeeves-server/SKILL.md
@@ -127,7 +127,11 @@ Caddy handles TLS certificate provisioning automatically. Ensure DNS A/AAAA reco
 npx @karmaniverous/jeeves-server-openclaw install
 ```
 
-Configure the plugin in `openclaw.json` with `apiUrl` and `pluginKey` (matching the `_plugin` key seed from server config). Restart the OpenClaw gateway.
+Configure the plugin in `openclaw.json` with `apiUrl` and `pluginKey` (matching the `_plugin` key seed from server config). 
+
+**Important:** Add `"jeeves-server-openclaw"` to the `tools.allow` array in `openclaw.json` so the agent can use the plugin's tools.
+
+Restart the gateway to load the plugin.
 
 ## Troubleshooting
 

--- a/packages/openclaw/src/helpers.test.ts
+++ b/packages/openclaw/src/helpers.test.ts
@@ -14,7 +14,7 @@ import {
 describe('deriveKey', () => {
   it('produces a hex string', () => {
     const key = deriveKey('test-seed');
-    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    expect(key).toMatch(/^[0-9a-f]{32}$/);
   });
 
   it('is deterministic', () => {
@@ -31,7 +31,7 @@ describe('deriveKey', () => {
     const seed = 'test-seed-12345';
     // Manually compute what computeInsiderKey produces
     const { createHmac } = await import('node:crypto');
-    const expected = createHmac('sha256', seed).update('insider').digest('hex');
+    const expected = createHmac('sha256', seed).update('insider').digest('hex').substring(0, 32);
     expect(deriveKey(seed)).toBe(expected);
   });
 });

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -54,7 +54,7 @@ export function getPluginKey(api: PluginApi): string | undefined {
 
 /** Derive HMAC key from seed. */
 export function deriveKey(seed: string): string {
-  return createHmac('sha256', seed).update('insider').digest('hex');
+  return createHmac('sha256', seed).update('insider').digest('hex').substring(0, 32);
 }
 
 /** Append auth key query param to a URL. */

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -30,8 +30,12 @@ describe('generateServerMenu', () => {
       json: () => ({
         version: '3.0.0',
         port: 1934,
-        exportFormats: ['pdf', 'docx'],
-        chrome: true,
+        exports: {
+          documents: ['pdf', 'docx'],
+          directories: ['zip'],
+          diagrams: ['svg', 'png'],
+          chromeAvailable: true,
+        },
       }),
     } as unknown as Response);
     const menu = await generateServerMenu('http://localhost:1934');
@@ -45,8 +49,10 @@ describe('generateServerMenu', () => {
       json: () => ({
         version: '3.0.0',
         port: 1934,
-        exportFormats: ['docx'],
-        chrome: false,
+        exports: {
+          documents: ['docx'],
+          chromeAvailable: false,
+        },
       }),
     } as unknown as Response);
     const menu = await generateServerMenu('http://localhost:1934');
@@ -60,7 +66,7 @@ describe('generateServerMenu', () => {
         version: '3.0.0',
         port: 1934,
         events: [{ name: 'webhook', pattern: '/event/*' }],
-        insiderCount: 3,
+        auth: { insiderCount: 3 },
       }),
     } as unknown as Response);
     const menu = await generateServerMenu('http://localhost:1934');

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -2,28 +2,33 @@
  * Generates the Server menu string for TOOLS.md injection.
  */
 
-import { fetchJson } from './helpers.js';
+import { fetchJson, withAuth } from './helpers.js';
 
 interface StatusResponse {
   version?: string;
   uptime?: number;
   port?: number;
   chrome?: boolean;
-  exportFormats?: string[];
+  exports?: {
+    documents?: string[];
+    directories?: string[];
+    diagrams?: string[];
+    chromeAvailable?: boolean;
+  };
   services?: Record<string, { url: string; reachable: boolean }>;
-  insiderCount?: number;
-  events?: Array<{ name: string; pattern?: string }>;
-  diagrams?: string[];
+  auth?: { insiderCount?: number; keyCount?: number };
+  events?: Array<{ name: string; cmd?: string }>;
+  diagrams?: { mermaid?: boolean; plantuml?: { localJar?: boolean; servers?: string[] } };
 }
 
 /**
  * Fetch server status and generate a Markdown menu string.
  */
-export async function generateServerMenu(apiUrl: string): Promise<string> {
+export async function generateServerMenu(apiUrl: string, keySeed?: string): Promise<string> {
   let status: StatusResponse;
 
   try {
-    status = (await fetchJson(apiUrl + '/api/status', {
+    status = (await fetchJson(withAuth(apiUrl + '/api/status', keySeed), {
       signal: AbortSignal.timeout(5000),
     })) as StatusResponse;
   } catch {
@@ -41,21 +46,39 @@ export async function generateServerMenu(apiUrl: string): Promise<string> {
     '',
   ];
 
-  // Export formats
-  if (status.exportFormats && status.exportFormats.length > 0) {
-    lines.push('### Export Formats');
-    lines.push('Available: ' + status.exportFormats.join(', '));
-    if (!status.chrome) {
-      lines.push('> **Note:** Chrome not detected — PDF export unavailable.');
+  // Export capabilities
+  if (status.exports) {
+    lines.push('### Export');
+    if (status.exports.documents) {
+      lines.push('* **Documents** (Markdown/HTML): ' + status.exports.documents.join(', '));
+      if (!status.exports.chromeAvailable) {
+        lines.push('  > Chrome not detected \u2014 PDF export unavailable.');
+      }
     }
+    if (status.exports.directories) {
+      lines.push('* **Directories**: ' + status.exports.directories.join(', '));
+    }
+    if (status.exports.diagrams) {
+      lines.push('* **Diagrams**: ' + status.exports.diagrams.join(', '));
+    }
+    lines.push('* **All files**: raw download');
+    lines.push('Use `server_link_info` to check available formats for a specific path.');
     lines.push('');
   }
 
   // Diagram support
-  if (status.diagrams && status.diagrams.length > 0) {
-    lines.push('### Diagram Support');
-    lines.push('Supported languages: ' + status.diagrams.join(', '));
-    lines.push('');
+  if (status.diagrams) {
+    const langs: string[] = [];
+    if (status.diagrams.mermaid) langs.push('Mermaid');
+    if (status.diagrams.plantuml) {
+      const pl = status.diagrams.plantuml;
+      langs.push('PlantUML' + (pl.localJar ? ' (local jar)' : ' (server-only)'));
+    }
+    if (langs.length > 0) {
+      lines.push('### Diagrams');
+      lines.push('Supported: ' + langs.join(', '));
+      lines.push('');
+    }
   }
 
   // Connected services
@@ -83,10 +106,10 @@ export async function generateServerMenu(apiUrl: string): Promise<string> {
     lines.push('');
   }
 
-  // Insider count
-  if (status.insiderCount !== undefined) {
+  // Access info
+  if (status.auth?.insiderCount !== undefined) {
     lines.push('### Access');
-    lines.push(String(status.insiderCount) + ' insider(s) configured.');
+    lines.push(String(status.auth.insiderCount) + ' insider(s) configured.');
     lines.push('');
   }
 

--- a/packages/openclaw/src/toolsWriter.ts
+++ b/packages/openclaw/src/toolsWriter.ts
@@ -5,7 +5,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import { getApiUrl, type PluginApi } from './helpers.js';
+import { getApiUrl, getPluginKey, type PluginApi } from './helpers.js';
 import { generateServerMenu } from './promptInjection.js';
 
 const REFRESH_INTERVAL_MS = 60_000;
@@ -65,7 +65,8 @@ function upsertServerContent(existing: string, serverMenu: string): string {
  */
 async function refreshToolsMd(api: PluginApi): Promise<boolean> {
   const apiUrl = getApiUrl(api);
-  const menu = await generateServerMenu(apiUrl);
+  const keySeed = getPluginKey(api);
+  const menu = await generateServerMenu(apiUrl, keySeed);
 
   if (menu === lastWrittenMenu) return false;
 
@@ -94,9 +95,13 @@ async function refreshToolsMd(api: PluginApi): Promise<boolean> {
  * Start the periodic TOOLS.md writer.
  */
 export function startToolsWriter(api: PluginApi): void {
-  refreshToolsMd(api).catch((err: unknown) => {
-    console.error('[jeeves-server] Failed to write TOOLS.md:', err);
-  });
+  // Defer first write to allow OpenClaw to fully populate api.config
+  // (plugin config may not be available at register() time).
+  setTimeout(() => {
+    refreshToolsMd(api).catch((err: unknown) => {
+      console.error('[jeeves-server] Failed initial TOOLS.md write:', err);
+    });
+  }, 5000);
 
   if (intervalHandle) clearInterval(intervalHandle);
 

--- a/packages/service/src/routes/api/middleware.ts
+++ b/packages/service/src/routes/api/middleware.ts
@@ -24,6 +24,7 @@ export function addAuthMiddleware(fastify: FastifyInstance): void {
     if (request.url.startsWith('/api/content-link/')) return;
     if (request.url.startsWith('/api/auth/status')) return;
     if (request.url.startsWith('/api/diagram/')) return;
+    if (request.url.startsWith('/api/status')) return;
 
     const config = getConfig();
 

--- a/packages/service/src/routes/api/status.test.ts
+++ b/packages/service/src/routes/api/status.test.ts
@@ -29,7 +29,7 @@ vi.mock('../../config/index.js', () => ({
 const { statusRoutes } = await import('./status.js');
 
 describe('GET /api/status', () => {
-  it('returns structured status for insider requests', async () => {
+  it('returns structured status', async () => {
     // Create a minimal Fastify-like test harness
     const routes: Record<string, (req: unknown) => Promise<unknown>> = {};
     const fakeFastify = {
@@ -53,20 +53,11 @@ describe('GET /api/status', () => {
     expect((status.auth as { insiderCount: number }).insiderCount).toBe(2);
     expect((status.auth as { keyCount: number }).keyCount).toBe(1);
     expect(status.events).toHaveLength(2);
-    expect(status.exportFormats).toEqual(['pdf', 'docx', 'zip']);
+    const exports = status.exports as { documents: string[]; directories: string[]; diagrams: string[]; chromeAvailable: boolean };
+    expect(exports.documents).toEqual(['pdf', 'docx']);
+    expect(exports.directories).toEqual(['zip']);
+    expect(exports.diagrams).toEqual(['svg', 'png']);
+    expect(exports.chromeAvailable).toBe(true);
     expect((status.diagrams as { mermaid: boolean }).mermaid).toBe(true);
-  });
-
-  it('rejects non-insider requests', async () => {
-    const routes: Record<string, (req: unknown) => Promise<unknown>> = {};
-    const fakeFastify = {
-      get: (path: string, handler: (req: unknown) => Promise<unknown>) => {
-        routes[path] = handler;
-      },
-    };
-
-    await statusRoutes(fakeFastify as never, {});
-    const result = await routes['/api/status']({ accessMode: 'outsider' });
-    expect(result).toEqual({ error: 'Insider auth required' });
   });
 });

--- a/packages/service/src/routes/api/status.ts
+++ b/packages/service/src/routes/api/status.ts
@@ -19,29 +19,27 @@ interface ServiceStatus {
 }
 
 async function checkService(url: string): Promise<ServiceStatus> {
-  try {
-    const res = await fetch(`${url}/status`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    if (res.ok) {
-      const data = (await res.json()) as { version?: string };
-      return { url, reachable: true, version: data.version };
+  // Try /status first (watcher), then /health (runner)
+  for (const endpoint of ['/status', '/health']) {
+    try {
+      const res = await fetch(`${url}${endpoint}`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { version?: string };
+        return { url, reachable: true, version: data.version };
+      }
+    } catch {
+      // try next endpoint
     }
-    return { url, reachable: false };
-  } catch {
-    return { url, reachable: false };
   }
+  return { url, reachable: false };
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const statusRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/api/status', async (request) => {
     const config = getConfig();
-
-    // Only insiders get status
-    if (request.accessMode !== 'insider') {
-      return { error: 'Insider auth required' };
-    }
 
     const [watcher, runner] = await Promise.all([
       config.watcherUrl ? checkService(config.watcherUrl) : null,
@@ -65,9 +63,14 @@ export const statusRoutes: FastifyPluginAsync = async (fastify) => {
         name,
         cmd: schema.cmd,
       })),
-      exportFormats: ['pdf', 'docx', 'zip'],
+      exports: {
+        documents: ['pdf', 'docx'],
+        directories: ['zip'],
+        diagrams: ['svg', 'png'],
+        chromeAvailable: Boolean(config.chromePath),
+      },
       diagrams: {
-        mermaid: true, // bundled via @mermaid-js/mermaid-cli
+        mermaid: true,
         plantuml: {
           localJar: Boolean(config.plantuml.jarPath),
           servers: config.plantuml.servers,


### PR DESCRIPTION
## Changes

- Fix \deriveKey()\ to truncate to 32 chars (match server's \computeInsiderKey\)
- Add auth (\withAuth\ + \pluginKey\) to \generateServerMenu\ status fetch
- Defer first TOOLS.md write by 5s (config may not be populated at register time)
- Make \/api/status\ public (remove insider auth requirement from middleware)
- Add \/health\ fallback in \checkService\ for runner compatibility
- Restructure export formats: documents/directories/diagrams/raw with \All files: raw download\
- Update status response: structured exports, diagrams, auth objects
- Update all tests to match new response shapes

## Testing

- 30/30 openclaw plugin tests pass
- 1/1 status endpoint test passes
- Manual verification: TOOLS.md populates correctly, \server_status\ tool works