### PR TITLE
docs: refresh README + guides for v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,48 +2,46 @@
 
 **Turn AI-authored documents into business-ready deliverables.**
 
-## The Problem
+A self-hosted file browser, document viewer, and webhook gateway. Author documents in Markdown with your AI assistant, then share them as beautifully rendered pages, PDFs, or Word documents — no friction, no external dependencies.
 
-You're working with an AI assistant. Together, you're producing real work — design documents, technical specs, integration plans, meeting summaries. The output is Markdown, because that's the native authoring format for AI: structured, version-controllable, rich with embedded code and diagrams.
+## Packages
 
-Now share that work with your colleagues.
+This is a monorepo with two published packages:
 
-You can't send them a `.md` file. You can't ask them to install a Markdown viewer. You need something they can read in a browser, download as a PDF, or open in Word — today, without friction.
+| Package | Description |
+|---------|-------------|
+| [`@karmaniverous/jeeves-server`](packages/service/) | The server — file browser, document renderer, export engine, event gateway |
+| [`@karmaniverous/jeeves-server-openclaw`](packages/openclaw/) | OpenClaw plugin — gives AI agents tools for browsing, sharing, and exporting |
 
-## The Solution
+## Quick Start
 
-Jeeves Server gives you a secure, polished window into the machine where your AI assistant lives. It turns the raw output of AI collaboration into something your team can actually use:
+```bash
+# Install globally
+npm install -g @karmaniverous/jeeves-server
 
-- **Browse and view** any file on the server — Markdown renders beautifully with table of contents, syntax-highlighted code, and Mermaid diagrams
-- **Share securely** — generate expiring links for external recipients, no login required
-- **Export instantly** — one-click PDF and DOCX downloads, perfectly rendered
-- **Stay in control** — Google OAuth for your team, scoped API keys for integrations, all zero-trust
+# Create a config file (JSON, YAML, JS, or TS — via cosmiconfig)
+# See guides/setup.md for full config reference
+cat > jeeves-server.config.json << 'EOF'
+{
+  "chromePath": "/usr/bin/chromium-browser",
+  "auth": {
+    "modes": ["keys"]
+  },
+  "keys": {
+    "_internal": "generate-a-random-hex-string",
+    "primary": "another-random-hex-string"
+  }
+}
+EOF
 
-You don't author documents here. That's what your AI assistant is for. Jeeves Server is the publishing layer — the bridge between the laboratory and the boardroom.
+# Start the server (default port: 1934)
+jeeves-server start
+```
 
-## Event Gateway
-
-Jeeves Server also includes a **webhook gateway** — a durable, schema-validated event processing pipeline. External services (Notion, GitHub, CI/CD systems, anything that sends webhooks) can POST to your server, and Jeeves will:
-
-- **Validate** the payload against JSON Schema rules
-- **Transform** the body using JsonMap (extract just the fields you need)
-- **Queue** matched events in a durable JSONL queue that survives restarts
-- **Dispatch** to shell commands with the transformed payload on stdin
-
-This makes Jeeves Server a natural integration hub for the same AI-assisted workflow: your assistant writes automation scripts, Jeeves Server receives the triggers, and the scripts execute on the same machine where everything else lives. No Lambda functions, no cloud queues — just a webhook URL and a command.
-
-See the [Event Gateway guide](guides/event-gateway.md) for setup and configuration.
-
-## Why Markdown?
-
-Markdown is **the** native document format for AI collaboration:
-
-- AI assistants read and write it natively — no format translation, no lossy conversion
-- It supports everything business documents need: headings, tables, code blocks, diagrams, links
-- It's plain text — version-controllable, diffable, mergeable
-- It's the format your assistant already thinks in
-
-The gap has always been the last mile: getting Markdown into the hands of people who don't know what Markdown is. Jeeves Server closes that gap.
+Generate key seeds with:
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
 
 ## Features
 
@@ -51,49 +49,86 @@ The gap has always been the last mile: getting Markdown into the hands of people
 - **Markdown Rendering** — Prose with TOC sidebar, adjustable reading width, dark/light themes
 - **PDF & DOCX Export** — One-click, perfectly rendered, business-ready
 - **Code Highlighting** — Syntax highlighting with copy buttons
-- **SVG, Mermaid & PlantUML Diagrams** — Rendered inline with pan/zoom; PlantUML uses a fallback pipeline (local jar → private servers → community server)
-- **Embedded Diagrams in Markdown** — `mermaid` and `plantuml` fenced code blocks render as inline SVGs (GitHub convention)
+- **SVG, Mermaid & PlantUML Diagrams** — Rendered inline with pan/zoom; Mermaid is bundled, PlantUML uses a fallback pipeline (local jar → private servers → community server)
+- **Embedded Diagrams in Markdown** — `mermaid` and `plantuml` fenced code blocks render as inline SVGs
 - **Secure Sharing** — Expiring links with HMAC signatures, scoped access
+- **Named Access Scopes** — Define reusable scope policies, reference them by name across insiders and keys
 - **Event Gateway** — Webhook receiver with JSON Schema validation and durable queue
+- **Semantic Search** — Full-text search via [jeeves-watcher](https://github.com/karmaniverous/jeeves-watcher) integration
+- **OpenClaw Plugin** — AI agents can browse, share, export, and query server status via tools
+- **CLI** — `jeeves-server start`, `config validate`, `config show`, `service install`
 - **Zero CDN** — All assets served locally, no external dependencies
+
+## Configuration
+
+Jeeves Server uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) for configuration. It searches for:
+
+- `jeeves-server.config.json` / `.yaml` / `.yml`
+- `jeeves-server.config.js` / `.ts` / `.mjs` / `.cjs`
+- `.jeeves-serverrc` / `.jeeves-serverrc.json` / `.jeeves-serverrc.yaml`
+- `package.json` (`"jeeves-server"` key)
+
+Configuration is validated at startup against a [Zod](https://github.com/colinhacks/zod) schema. The schema in `packages/service/src/config/schema.ts` is the single source of truth.
+
+**Environment variable substitution:** Use `${VAR_NAME}` in string config values and they'll be replaced from `process.env` at load time.
+
+See the [Setup & Configuration](packages/service/guides/setup.md) guide for full details.
+
+## CLI
+
+```bash
+# Start the server
+jeeves-server start [--config <path>]
+
+# Validate configuration
+jeeves-server config validate [--config <path>]
+
+# Show resolved configuration (insiders, keys, scopes)
+jeeves-server config show [--config <path>]
+
+# Print service install/uninstall instructions (NSSM on Windows, systemd on Linux)
+jeeves-server service install [--config <path>] [--name <service-name>]
+jeeves-server service uninstall [--name <service-name>]
+
+# Manage installed service
+jeeves-server service start|stop|restart [--name <service-name>]
+```
 
 ## Guides
 
-- [Setup & Configuration](guides/setup.md) — Installation, auth modes (Google OAuth & key-based), config structure, and getting running
-- [Insiders, Outsiders & Sharing](guides/sharing.md) — The access model, how share links work, key derivation, expiry, and rotation
-- [Exporting & Downloads](guides/exports.md) — PDF, DOCX, and ZIP export, Puppeteer setup, troubleshooting, and what affects rendered output
-- [Event Gateway](guides/event-gateway.md) — Webhook receiving, JSON Schema matching, body mapping, durable queue processing, and monitoring
-- [Deployment](guides/deployment.md) — Running as a service (Windows & Linux), reverse proxy setup, HTTPS, Google OAuth for production, and updates
-- [API & Integration](guides/api-integration.md) — Programmatic access, endpoint reference, Windows path conversion, generating share links, and notes for AI assistants
-
-## Live Demo
-
-The 📖 button in the header is itself a live external share link — it points to this very README—in the working directory on a live production Jeeves Server—with `depth=2` (so you can follow links to the guides) and `dirs=false` (no directory browsing). If you're reading this in Jeeves Server, you're seeing the deep share feature in action. If you're reading this on GitHub, click [here](https://jeeves.johngalt.id/browse/e/jeeves-server/README.md?key=58f33049a73af8c3e694afa45eca426c&d=2&dirs=0&s=NoIg9ApmBWEQbhAzgWiRATojYBKBRAQQBEBZfAOgFsATEAXSA) to see for yourself.
+- [Setup & Configuration](packages/service/guides/setup.md) — Installation, auth modes, config structure, named scopes
+- [Insiders, Outsiders & Sharing](packages/service/guides/sharing.md) — Access model, share links, key derivation, expiry, rotation
+- [Exporting & Downloads](packages/service/guides/exports.md) — PDF, DOCX, SVG, PNG, and ZIP export
+- [Event Gateway](packages/service/guides/event-gateway.md) — Webhook receiving, JSON Schema matching, body mapping, durable queue
+- [Deployment](packages/service/guides/deployment.md) — Running as a service, reverse proxy, HTTPS, updates
+- [API & Integration](packages/service/guides/api-integration.md) — Endpoint reference, path conversion, share link generation
+- [OpenClaw Integration](packages/openclaw/guides/openclaw-integration.md) — Plugin installation, configuration, tool reference
 
 ## Platform Support
 
-Jeeves Server runs on **Windows** and **Linux**.
-
-- **Windows:** File browser auto-discovers drive letters (A-Z). Chrome path defaults to Program Files.
-- **Linux:** File browser uses configurable `roots` in `jeeves.config.ts` (e.g. `{ home: '/home', projects: '/opt/projects' }`). Chromium path is typically `/usr/bin/chromium-browser`.
+- **Windows:** File browser auto-discovers drive letters (A–Z). Chrome path defaults to Program Files.
+- **Linux:** File browser uses configurable `roots` (e.g. `{ home: '/home', projects: '/opt/projects' }`). Chromium path is typically `/usr/bin/chromium-browser`.
 
 Both platforms are tested in CI (GitHub Actions on Ubuntu, Node 20 + 22).
 
-## Quick Start
+## Development
 
 ```bash
 git clone https://github.com/karmaniverous/jeeves-server.git
 cd jeeves-server
 npm install
-cp jeeves.config.template.ts jeeves.config.ts  # Configure
+
+# Build everything
 npm run build
-cd client && npx vite build --outDir ../dist/client && cd ..
-node dist/server.js
+
+# Run all checks
+npm run typecheck
+npm run lint
+npm test
+npm run knip
 ```
 
-## Documentation
-
-Full requirements and architecture: [`.stan/system/stan.requirements.md`](.stan/system/stan.requirements.md)
+The monorepo uses npm workspaces. The dev server runs on port 19340 by default.
 
 ## License
 

--- a/knip.json
+++ b/knip.json
@@ -18,8 +18,5 @@
     },
     "packages/openclaw": {}
   },
-  "ignoreBinaries": [
-    "vite"
-  ],
   "ignoreExportsUsedInFile": true
 }

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -1,0 +1,49 @@
+# @karmaniverous/jeeves-server-openclaw
+
+OpenClaw plugin for Jeeves Server. Provides agents with tools for:
+
+- Server status and capabilities
+- File/directory metadata browsing
+- Share link generation
+- Export (PDF/DOCX/SVG/PNG/ZIP)
+- Event gateway visibility
+
+## Install
+
+```bash
+npx @karmaniverous/jeeves-server-openclaw install
+# Restart OpenClaw gateway after installing
+```
+
+## Configuration
+
+### Server
+
+Add an unscoped `_plugin` key to your Jeeves Server config:
+
+```json
+{ "keys": { "_plugin": "<seed>" } }
+```
+
+### OpenClaw
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "jeeves-server-openclaw": {
+        "enabled": true,
+        "config": {
+          "apiUrl": "http://127.0.0.1:1934",
+          "pluginKey": "<same-seed-as-server-_plugin>"
+        }
+      }
+    }
+  }
+}
+```
+
+## Docs
+
+- OpenClaw Integration: ./guides/openclaw-integration.md
+

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -1,0 +1,45 @@
+# @karmaniverous/jeeves-server
+
+Jeeves Server — secure file browser, markdown viewer, and webhook gateway with PDF/DOCX export and expiring share links.
+
+## Install
+
+```bash
+npm install -g @karmaniverous/jeeves-server
+```
+
+## Run
+
+Jeeves Server loads configuration via cosmiconfig. Create a config file such as `jeeves-server.config.json` and run:
+
+```bash
+jeeves-server start [--config <path>]
+```
+
+Default port: **1934**.
+
+## CLI
+
+```bash
+jeeves-server start
+jeeves-server config validate
+jeeves-server config show
+jeeves-server service install
+jeeves-server service uninstall
+jeeves-server service start|stop|restart
+```
+
+## Docs
+
+- Setup & Configuration: ../../packages/service/guides/setup.md
+- Deployment: ../../packages/service/guides/deployment.md
+- Sharing: ../../packages/service/guides/sharing.md
+- Exports: ../../packages/service/guides/exports.md
+- Event Gateway: ../../packages/service/guides/event-gateway.md
+- API Integration: ../../packages/service/guides/api-integration.md
+
+## Public endpoints
+
+- `GET /health` — health check
+- `GET /api/status` — server metadata (public; no auth)
+

--- a/packages/service/about.md
+++ b/packages/service/about.md
@@ -1,6 +1,6 @@
 # Jeeves Server
 
-A lightweight file browser and document viewer with secure, shareable links.
+A self-hosted file browser, document viewer, and webhook gateway with secure sharing and one-click PDF/DOCX export.
 
 ## Why Markdown?
 
@@ -8,38 +8,38 @@ A lightweight file browser and document viewer with secure, shareable links.
 
 But in the business world, you can't share `.md` files — people expect PDFs and Word documents.
 
-**Jeeves Server bridges this gap.** Author your documents in Markdown, review them beautifully rendered in the browser, then export to PDF or DOCX with one click when it's time to share with colleagues, clients, or stakeholders.
+**Jeeves Server bridges this gap.** Author your documents in Markdown, review them beautifully rendered in the browser, then export to PDF or DOCX with one click when it's time to share.
 
 ## Features
 
-- **File Browser** — Navigate your filesystem through a web interface
+- **File Browser** — Navigate your filesystem through a modern web interface
 - **Markdown Rendering** — `.md` files render as styled HTML with table of contents
 - **PDF & DOCX Export** — One-click export for business-ready documents
 - **Code Highlighting** — Source files display with syntax highlighting
+- **Mermaid & PlantUML Diagrams** — Rendered inline with pan/zoom
 - **Dark/Light Themes** — Toggle between themes; preference is saved
 - **Secure Sharing** — Generate expiring links for external recipients
+- **Semantic Search** — Full-text search across indexed documents (via jeeves-watcher integration)
 
 ## Authentication
 
-Jeeves uses **path-specific keys** for authentication. There are two access modes:
+Jeeves uses two access modes:
 
 ### Insider Access
 
-Insider links use a single master key that works for any path. With insider access you can:
+Insider links use a derived key that works within configured scopes. With insider access you can:
 
-- Navigate freely between directories and files
+- Navigate freely between directories and files (within scopes)
 - Generate shareable links for others
-- Rotate the API key (invalidates all existing links)
+- Rotate your API key (invalidates all existing links)
+- Search across indexed documents
 
 ### Outsider Access
 
 Outsider links are path-specific and can optionally expire. With outsider access you can:
 
 - View the specific file or directory shared with you
-- Download raw files
-- Share the same link with others
-
-Outsiders cannot navigate to parent directories or other paths.
+- Download raw files and exports
 
 ## Header Controls
 
@@ -47,35 +47,11 @@ Outsiders cannot navigate to parent directories or other paths.
 |--------|-------------|
 | 🎩 | Home — return to drive list (insider only) |
 | ? | About — this page |
-| 🔑 | Rotate API Key — generates a new master key, invalidating all existing links |
-| ⬇ Raw | Download the raw file |
-| 📄 PDF | Export markdown as PDF |
-| 📝 DOCX | Export markdown as Word document |
-| Inside | Copy insider link to clipboard |
-| Outside | Generate outsider link (optionally with expiry) |
+| 🔑 | Rotate API Key — generates a new key, invalidating all existing links |
+| ⬇ | Download/Export — raw file, PDF, DOCX, or ZIP |
+| 🔗 | Share — copy insider or outsider link with optional expiry |
+| 🔎 | Search — semantic search across indexed documents |
 | 🌙/☀️ | Toggle dark/light theme |
-
-## Sharing Links
-
-### Insider Links
-
-Click **Inside** to copy the current page URL with insider access. Anyone with this link can navigate freely.
-
-### Outsider Links
-
-1. Enter an expiry in the input field (e.g., `15m`, `1h`, `7d`) or leave blank for no expiry
-2. Click **Outside** to generate and copy a path-specific link
-3. Share the link — recipients can only view this specific path
-
-## Key Rotation
-
-Click the 🔑 button to rotate the API key. This will:
-
-- Generate a new random API key
-- Invalidate **all** existing insider and outsider links
-- Redirect you to the same page with the new insider key
-
-The time since last rotation is shown next to the key button.
 
 ---
 

--- a/packages/service/guides/api-integration.md
+++ b/packages/service/guides/api-integration.md
@@ -4,15 +4,15 @@ How to interact with Jeeves Server programmatically — for scripts, bots, AI as
 
 ## Authentication for API Access
 
-All API requests authenticate via `?key=<insider-key>` URL parameter or session cookie. For programmatic access, use a key:
+All API requests (except `/health` and `/api/status`) authenticate via `?key=<insider-key>` URL parameter or session cookie.
 
-```typescript
-// In jeeves.config.ts
-keys: {
-  'ci-bot': 'random-seed-string',
-  // Scoped key for webhooks only:
-  'webhook': { key: 'another-seed', scopes: ['/event'] },
-},
+```json
+{
+  "keys": {
+    "ci-bot": "random-seed-string",
+    "webhook": { "key": "another-seed", "scopes": ["/event"] }
+  }
+}
 ```
 
 ### Getting the derived key
@@ -20,7 +20,6 @@ keys: {
 The config contains **seeds**. The actual URL key is derived via HMAC:
 
 ```bash
-# Get the insider key from a seed
 curl -s "http://localhost:1934/insider-key" -H "X-API-Key: <seed>"
 # Returns: { "key": "a1b2c3d4..." }
 ```
@@ -36,118 +35,78 @@ function insiderKey(seed) {
 
 ## API Endpoints
 
-### File Access
+### Public (no auth required)
 
-```bash
-# Get file content (rendered)
-GET /api/file/d/docs/design.md?key=<key>
-# Returns: { type: "markdown", html: "...", headings: [...], content: "...", fileName: "..." }
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Simple health check (200 OK) |
+| `GET` | `/api/status` | Server metadata: version, uptime, services, capabilities |
 
-# Get file content (raw text)
-GET /api/file/d/docs/design.md?key=<key>&mode=raw
-# Returns: { type: "text", content: "...", fileName: "..." }
+### File Access (auth required)
 
-# Get raw file bytes
-GET /path/d/docs/design.md?key=<key>&raw=1
-# Returns: file content with appropriate Content-Type
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/file/<path>` | File content (rendered HTML for markdown, raw for others) |
+| `GET` | `/api/raw/<path>` | Raw file bytes with appropriate Content-Type |
+| `GET` | `/api/link-info/<path>` | Query available views and export formats for a path |
 
-# Export as PDF
-GET /path/d/docs/design.md?key=<key>&export=pdf
-# Returns: application/pdf
+### Directory Access
 
-# Export as DOCX
-GET /path/d/docs/design.md?key=<key>&export=docx
-# Returns: application/vnd.openxmlformats-officedocument.wordprocessingml.document
-```
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/drives` | List available drives (Windows) or roots (Linux) |
+| `GET` | `/api/directory/<path>` | List directory contents |
 
-### Directory Listing
+### Export
 
-```bash
-# List drives
-GET /api/drives?key=<key>
-# Returns: { drives: [{ letter: "C", label: "System", ... }] }
-
-# List directory
-GET /api/directory/d/docs?key=<key>
-# Returns: { path: "d/docs", entries: [{ name: "...", type: "file"|"directory", ... }] }
-```
-
-### Authentication
-
-```bash
-# Check auth status
-GET /api/auth/status?key=<key>
-# Returns: { authenticated: true, email: "...", isInsider: true, mode: "key" }
-```
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/export/<path>?format=pdf\|docx\|zip` | Export file or directory |
+| `GET` | `/api/mermaid-export/<path>?format=svg\|png\|pdf` | Export Mermaid diagram |
+| `GET` | `/api/plantuml-export/<path>?format=svg\|png\|pdf\|eps` | Export PlantUML diagram |
 
 ### Sharing
 
-```bash
-# Get insider key (requires X-API-Key header with seed)
-GET /insider-key
-# Headers: X-API-Key: <seed>
-# Returns: { key: "a1b2c3d4..." }
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/insider-key` | Get derived insider key (requires `X-API-Key` header with seed) |
+| `GET` | `/key?path=<path>` | Compute outsider key for a path |
+| `POST` | `/rotate-key` | Rotate an insider's key (invalidates all their outsider links) |
 
-# Compute outsider key for a path
-GET /key?path=/d/docs/design.md
-# Headers: X-API-Key: <seed>
-# Returns: { key: "e5f6a7b8..." }
+### Authentication
 
-# Rotate a key
-POST /rotate-key
-# Body: { key: "<current-insider-key>" }
-```
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/auth/status` | Check authentication status and mode |
 
 ### Event Gateway
 
-```bash
-# Send a webhook
-POST /event?key=<webhook-key>
-Content-Type: application/json
-Body: { "type": "page.content_updated", "data": { "page_id": "abc123" } }
-# Returns: { matched: "notion-page-update" } or { matched: null }
-```
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/event` | Send a webhook (matched against configured schemas) |
 
-### Health
+### Search (requires watcher integration)
 
-```bash
-GET /health
-# Returns: 200 OK (no auth required)
-```
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/search` | Semantic search (proxied to jeeves-watcher) |
+| `GET` | `/api/search/facets` | Get filter facets for search UI (cached) |
 
 ## Converting Windows Paths to URLs
 
-Jeeves Server maps Windows filesystem paths to URL paths:
-
 ```
-D:\docs\design.md  →  /d/docs/design.md
-E:\projects\foo    →  /e/projects/foo
+D:\\docs\\design.md  →  /d/docs/design.md
+E:\\projects\\foo    →  /e/projects/foo
 ```
 
 **Conversion formula:**
 1. Replace backslashes with forward slashes
 2. Replace the drive letter + colon with lowercase letter
-3. Prepend the route prefix (`/path/` for legacy, `/browse/` for SPA, `/api/file/` for API)
+3. Prepend the route prefix (`/browse/` for SPA, `/api/file/` for API, `/path/` for legacy)
 
 ```javascript
-function winPathToUrl(winPath, prefix = '/path/') {
-  const urlPath = winPath
-    .replace(/\\/g, '/')
-    .replace(/^([A-Z]):/, (_, d) => d.toLowerCase());
-  return `${prefix}${urlPath}`;
-}
-
-// D:\docs\design.md → /path/d/docs/design.md
-// D:\docs\design.md → /browse/d/docs/design.md
-// D:\docs\design.md → /api/file/d/docs/design.md
-```
-
-```powershell
-# PowerShell equivalent
-function Convert-ToJeevesUrl {
-  param([string]$Path, [string]$Prefix = '/path/')
-  $urlPath = $Path -replace '\\','/' -replace '^([A-Z]):',{ $_.Groups[1].Value.ToLower() }
-  return "${Prefix}${urlPath}"
+function winPathToUrl(winPath, prefix = '/browse/') {
+  return prefix + winPath.replace(/\\\\/g, '/').replace(/^([A-Z]):/, (_, d) => d.toLowerCase());
 }
 ```
 
@@ -157,7 +116,7 @@ function Convert-ToJeevesUrl {
 
 ```javascript
 const insiderKey = computeInsiderKey(seed);
-const url = `https://jeeves.example.com/browse/d/docs/design.md?key=${insiderKey}`;
+const url = \`https://jeeves.example.com/browse/d/docs/design.md?key=\${insiderKey}\`;
 ```
 
 ### Outsider links (path-scoped)
@@ -169,68 +128,16 @@ function outsiderKey(seed, path) {
   const normalized = path.toLowerCase().replace(/^\/+|\/+$/g, '');
   return crypto.createHmac('sha256', seed).update(normalized).digest('hex').substring(0, 32);
 }
-
-function outsiderKeyWithExpiry(seed, path, expiryMs) {
-  const normalized = path.toLowerCase().replace(/^\/+|\/+$/g, '');
-  const data = `${normalized}|${expiryMs}`;
-  return crypto.createHmac('sha256', seed).update(data).digest('hex').substring(0, 32);
-}
-
-// Non-expiring outsider link
-const key = outsiderKey(seed, 'd/docs/design.md');
-const url = `https://jeeves.example.com/browse/d/docs/design.md?key=${key}`;
-
-// Expiring outsider link (1 week)
-const expiry = Date.now() + 7 * 24 * 60 * 60 * 1000;
-const key = outsiderKeyWithExpiry(seed, 'd/docs/design.md', expiry);
-const url = `https://jeeves.example.com/browse/d/docs/design.md?key=${key}&exp=${expiry}`;
 ```
 
-### Directory links
-
-Outsider keys for directories grant access to all descendants:
-
-```javascript
-// Share an entire directory
-const key = outsiderKey(seed, 'd/projects/client-x');
-const url = `https://jeeves.example.com/browse/d/projects/client-x?key=${key}`;
-// Grants access to all files under D:\projects\client-x\
-```
+See the [Sharing](sharing.md) guide for details on expiring links and directory sharing.
 
 ## For AI Assistants
 
-If you're an AI assistant working with Jeeves Server, here's what you need to know:
+If you're an AI assistant working with Jeeves Server:
 
-### Generating links to share with humans
-
-When your human asks you to share a document:
-
-1. **Convert the Windows path** to a URL path (see above)
-2. **Use the insider key** for team members, or generate an outsider key for external recipients
-3. **Choose the right route**: `/browse/` for browser viewing, `/path/` with `?export=pdf` for direct PDF download
-
-### Authoring documents
-
-Write Markdown files to the server's filesystem. Jeeves Server will render them beautifully. You can:
-- Embed Mermaid diagrams (rendered inline)
-- Embed SVG files (rendered with pan/zoom)
-- Use code blocks with language hints (syntax highlighted)
-- Reference other local files with relative paths
-
-### Checking server status
-
-```bash
-curl -s http://localhost:1934/health
-```
-
-### Triggering webhooks
-
-If you need to trigger an action via the event gateway:
-
-```bash
-curl -X POST "http://localhost:1934/event?key=<webhook-key>" \
-  -H "Content-Type: application/json" \
-  -d '{"action": "rebuild", "target": "docs"}'
-```
-
-Match this against a configured event schema to dispatch your handler.
+1. **Use the OpenClaw plugin** if available — it provides `server_status`, `server_browse`, `server_link_info`, `server_share`, `server_export`, and `server_event_status` tools
+2. **Convert Windows paths** to URL paths using the formula above
+3. **Use `/api/status`** for health checks (no auth required)
+4. **Prefer `/browse/` routes** for links you share with humans (renders the SPA)
+5. **Use `/api/export/` routes** for direct PDF/DOCX downloads

--- a/packages/service/guides/deployment.md
+++ b/packages/service/guides/deployment.md
@@ -2,57 +2,75 @@
 
 How to run Jeeves Server in production.
 
-> Jeeves Server runs on **Windows** and **Linux**. Both platforms are tested in CI.
-
 ## Prerequisites
 
-- **Node.js** ≥ 18
+- **Node.js** ≥ 20
 - **Chrome or Chromium** — for PDF/DOCX export via Puppeteer
 - **A domain** with HTTPS — required for Google OAuth and secure sharing
-- **A reverse proxy** — nginx, Caddy, or similar (recommended)
+- **A reverse proxy** — Caddy, nginx, or similar (recommended)
 
-### Optional Dependencies
+### Bundled Dependencies
 
-- **Java** (JDK 11+) — required for local PlantUML rendering with `!include` support. Without Java, PlantUML falls back to the community server (no `!include` support).
-- **PlantUML jar** — download from [plantuml.com/download](https://plantuml.com/download). Configure the path in `jeeves.config.ts` under `plantuml.jarPath`.
-- **Mermaid CLI** — for server-side Mermaid diagram rendering. Install with `npm install @mermaid-js/mermaid-cli` and configure `mermaidCliPath` in `jeeves.config.ts`.
+- **Mermaid CLI** — bundled as a direct dependency (`@mermaid-js/mermaid-cli`). No separate install needed.
+- **PlantUML jar** — downloaded automatically during `npm install` (via `postinstall` script). Requires Java (JDK 11+) at runtime for local rendering.
+
+## Installation
+
+```bash
+npm install -g @karmaniverous/jeeves-server
+```
+
+Create your config file (see [Setup & Configuration](setup.md)):
+
+```bash
+# Example: JSON config
+cat > /etc/jeeves-server.config.json << 'EOF'
+{
+  "chromePath": "/usr/bin/chromium-browser",
+  "auth": { "modes": ["keys"] },
+  "keys": {
+    "_internal": "your-random-hex-seed",
+    "primary": "another-random-hex-seed"
+  }
+}
+EOF
+```
 
 ## Running the Server
 
 ### Direct
 
 ```bash
-node dist/server.js
+jeeves-server start --config /path/to/jeeves-server.config.json
 ```
 
-The server listens on the port configured in `jeeves.config.ts` (default: 1934) on all interfaces (`0.0.0.0`).
+The server listens on the configured port (default: 1934) on all interfaces.
 
 ### As a Windows Service (NSSM)
 
-[NSSM](https://nssm.cc/) (Non-Sucking Service Manager) turns any executable into a Windows service:
+Use the built-in CLI to generate NSSM install commands:
 
 ```bash
-# Install the service
-nssm install JeevesServer "C:\Program Files\nodejs\node.exe" "E:\jeeves-server\dist\server.js"
-
-# Configure working directory
-nssm set JeevesServer AppDirectory "E:\jeeves-server"
-
-# Configure stdout/stderr logging
-nssm set JeevesServer AppStdout "E:\jeeves-server\logs\service-stdout.log"
-nssm set JeevesServer AppStderr "E:\jeeves-server\logs\service-stderr.log"
-
-# Start the service
-nssm start JeevesServer
+jeeves-server service install --config "C:\\config\\jeeves-server.config.json"
 ```
 
-**Service management:**
+This prints the `nssm install` commands. Run them, then:
+
 ```bash
+jeeves-server service start
+jeeves-server service stop
+jeeves-server service restart
+```
+
+Or use NSSM directly:
+
+```bash
+nssm install JeevesServer "C:\\Program Files\\nodejs\\node.exe" "<global-npm-path>\\@karmaniverous\\jeeves-server\\dist\\src\\cli\\index.js" start --config "C:\\config\\jeeves-server.config.json"
+nssm set JeevesServer AppDirectory "<working-dir>"
+nssm set JeevesServer AppStdout "<log-dir>\\service.log"
+nssm set JeevesServer AppStderr "<log-dir>\\service-error.log"
+nssm set JeevesServer Start SERVICE_AUTO_START
 nssm start JeevesServer
-nssm stop JeevesServer
-nssm restart JeevesServer
-nssm status JeevesServer
-nssm remove JeevesServer confirm   # Uninstall
 ```
 
 ### As a systemd Service (Linux)
@@ -66,8 +84,7 @@ After=network.target
 [Service]
 Type=simple
 User=jeeves
-WorkingDirectory=/opt/jeeves-server
-ExecStart=/usr/bin/node /opt/jeeves-server/dist/server.js
+ExecStart=/usr/bin/env jeeves-server start --config /etc/jeeves-server.config.json
 Restart=on-failure
 RestartSec=5
 Environment=NODE_ENV=production
@@ -79,69 +96,11 @@ WantedBy=multi-user.target
 ```bash
 sudo systemctl enable jeeves-server
 sudo systemctl start jeeves-server
-sudo systemctl status jeeves-server
-```
-
-### Linux Quick Start (Ubuntu/Debian)
-
-```bash
-# System packages
-sudo apt-get update && sudo apt-get install -y curl git build-essential chromium-browser caddy
-
-# Node.js 22
-curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
-sudo apt-get install -y nodejs
-
-# Clone and build
-cd /opt
-sudo git clone https://github.com/karmaniverous/jeeves-server.git
-cd jeeves-server
-npm ci
-cd client && npm ci && npx vite build --outDir ../dist/client && cd ..
-npx tsc
-
-# Configure
-cp jeeves.config.template.ts jeeves.config.ts
-# Edit jeeves.config.ts — set chromePath, roots, auth, keys, etc.
-echo '{}' > state.json
-```
-
-**Linux-specific config options:**
-
-```typescript
-{
-  // Chromium path (required for PDF/DOCX export)
-  chromePath: '/usr/bin/chromium-browser',
-
-  // Filesystem roots for the file browser (replaces Windows drive letters)
-  roots: {
-    home: '/home',
-    projects: '/opt/projects',
-  },
-
-  // Mermaid CLI path (optional, for .mmd diagram rendering)
-  mermaidCliPath: '/opt/mermaid-cli',
-}
-```
-
-On Windows, `roots` is ignored — the file browser auto-discovers drive letters. On Linux, if `roots` is omitted, it defaults to `{ root: '/' }`.
-
-**Puppeteer config** (for Chromium on Linux):
-
-Create `puppeteer.json` in the server root:
-```json
-{
-  "executablePath": "/usr/bin/chromium-browser",
-  "args": ["--no-sandbox", "--disable-setuid-sandbox"]
-}
 ```
 
 ## Reverse Proxy
 
-Running behind a reverse proxy is recommended for:
-- **HTTPS termination** — required for Google OAuth and secure key transmission
-- **Domain routing** — serve on a clean domain/subdomain
-- **Rate limiting** and request filtering
+Running behind a reverse proxy is recommended for HTTPS termination, domain routing, and rate limiting.
 
 ### Caddy (simplest)
 
@@ -169,14 +128,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-
-        # Large file uploads (for webhook bodies)
         client_max_body_size 10M;
-
-        # WebSocket support (if needed in future)
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
     }
 }
 
@@ -189,99 +141,43 @@ server {
 
 ## HTTPS
 
-**HTTPS is required** when using Google OAuth — Google will not redirect to an HTTP callback URL (except `localhost` for development).
+**HTTPS is required** when using Google OAuth — Google will not redirect to an HTTP callback URL (except `localhost`).
 
-**HTTPS is strongly recommended** even with key-only auth, because keys appear in URL parameters. Without HTTPS, keys are visible to network observers.
-
-### Options
-
-| Method | Effort | Best For |
-|--------|--------|----------|
-| **Caddy** | Minimal | Automatic HTTPS, zero config |
-| **Let's Encrypt + nginx** | Moderate | Fine-grained control |
-| **Cloudflare Tunnel** | Moderate | No port forwarding needed |
-
-## Google OAuth Setup for Production
-
-When using Google OAuth in production:
-
-1. **Add your domain** to the Google Cloud Console OAuth consent screen
-2. **Set the redirect URI** to `https://your-domain.com/auth/google/callback`
-3. **Update `jeeves.config.ts`** with the production credentials
-
-> **Dev vs Prod:** You can use different Google OAuth client IDs for development and production. Each `jeeves.config.ts` is gitignored and instance-specific.
-
-### Multiple environments
-
-Run dev and prod on the same machine using different ports:
-
-```typescript
-// Dev: jeeves.config.ts (port 3457)
-port: 3457,
-auth: {
-  google: {
-    clientId: 'dev-client-id.apps.googleusercontent.com',
-    clientSecret: 'dev-secret',
-  },
-},
-
-// Prod: jeeves.config.ts (port 1934)
-port: 1934,
-auth: {
-  google: {
-    clientId: 'prod-client-id.apps.googleusercontent.com',
-    clientSecret: 'prod-secret',
-  },
-},
-```
-
-Each needs its own Google OAuth redirect URI registered.
+**HTTPS is strongly recommended** even with key-only auth, because keys appear in URL parameters.
 
 ## Health Checks
 
-The `/health` endpoint requires no authentication:
-
 ```bash
+# No auth required
 curl http://localhost:1934/health
-# Returns 200 OK
+
+# Detailed server status (no auth required)
+curl http://localhost:1934/api/status
 ```
 
-Use this for:
-- Load balancer health checks
-- Service monitoring (Uptime Kuma, Prometheus, etc.)
-- NSSM/systemd restart triggers
+The `/api/status` endpoint returns version, uptime, connected services, export capabilities, and event schemas. Use `/health` for simple load balancer checks and `/api/status` for monitoring dashboards.
 
 ## Updating
 
 ```bash
-cd /path/to/jeeves-server
-git pull
-
-# Full rebuild
-npm install
-npm run build
-cd client && npx vite build --outDir ../dist/client && cd ..
+# Update the global package
+npm install -g @karmaniverous/jeeves-server@latest
 
 # Restart the service
-nssm restart JeevesServer           # Windows
-sudo systemctl restart jeeves-server # Linux
+jeeves-server service restart    # or: nssm restart JeevesServer / systemctl restart jeeves-server
 ```
-
-> ⚠️ Remember: `npm run build` deletes `dist/` entirely. Always rebuild the client after the server.
 
 ## File Permissions
 
 The server needs:
-- **Read access** to any files you want to serve (drives, directories)
-- **Write access** to its own directory for `state.json` and `logs/`
+- **Read access** to any files you want to serve
+- **Write access** to its working directory for `state.json` and logs
 - **Execute access** to Chrome/Chromium for PDF export
 - **Execute access** to event handler commands
 
 ## Backups
 
 Key files to back up:
-- `jeeves.config.ts` — your configuration (secrets!)
+- Your config file (`jeeves-server.config.json`) — contains secrets
 - `state.json` — insider keys and rotation state
-- `logs/event-queue.jsonl` + `logs/event-queue.cursor` — pending events
-
-The server code itself is in git — no need to back up `dist/` or `node_modules/`.
+- Event queue files — `logs/event-queue.jsonl` + `logs/event-queue.cursor`

--- a/packages/service/guides/event-gateway.md
+++ b/packages/service/guides/event-gateway.md
@@ -8,37 +8,32 @@ Jeeves Server includes a webhook gateway that receives HTTP POST requests, valid
 
 ## Configuration
 
-Events are defined in `jeeves.config.ts`:
+Events are defined in your config file:
 
-```typescript
-events: {
-  'notion-page-update': {
-    // JSON Schema matched against the incoming POST body
-    schema: {
-      type: 'object',
-      properties: {
-        type: { const: 'page.content_updated' },
+```json
+{
+  "events": {
+    "notion-page-update": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "type": { "const": "page.content_updated" }
+        },
+        "required": ["type"]
       },
-      required: ['type'],
-    },
-
-    // Shell command to execute when matched
-    cmd: 'node /path/to/handler.js',
-
-    // Optional: transform the body before passing to the command
-    map: {
-      pageId: {
-        '$': { method: '$.lib._.get', params: ['$.input', 'data.page_id'] },
+      "cmd": "node /path/to/handler.js",
+      "map": {
+        "pageId": {
+          "$": { "method": "$.lib._.get", "params": ["$.input", "data.page_id"] }
+        },
+        "type": {
+          "$": { "method": "$.lib._.get", "params": ["$.input", "type"] }
+        }
       },
-      type: {
-        '$': { method: '$.lib._.get', params: ['$.input', 'type'] },
-      },
-    },
-
-    // Optional: override default timeout (ms)
-    timeoutMs: 60000,
-  },
-},
+      "timeoutMs": 60000
+    }
+  }
+}
 ```
 
 ### Schema matching
@@ -68,15 +63,15 @@ When `map` is omitted, the full webhook body is passed as-is.
 
 **Example — Notion sends a large payload, we extract just two fields:**
 
-```typescript
-map: {
-  pageId: {
-    '$': { method: '$.lib._.get', params: ['$.input', 'data.page_id'] },
+```json
+{
+  "pageId": {
+    "$": { "method": "$.lib._.get", "params": ["$.input", "data.page_id"] }
   },
-  type: {
-    '$': { method: '$.lib._.get', params: ['$.input', 'type'] },
-  },
-},
+  "type": {
+    "$": { "method": "$.lib._.get", "params": ["$.input", "type"] }
+  }
+}
 ```
 
 Input: `{ type: "page.content_updated", data: { page_id: "abc123", ... } }`
@@ -86,13 +81,15 @@ Output to command: `{ pageId: "abc123", type: "page.content_updated" }`
 
 Webhook callers must authenticate with a key that has scope access to `/event`:
 
-```typescript
-keys: {
-  'webhook-notion': {
-    key: 'random-seed-string',
-    scopes: ['/event'],
-  },
-},
+```json
+{
+  "keys": {
+    "webhook-notion": {
+      "key": "random-seed-string",
+      "scopes": ["/event"]
+    }
+  }
+}
 ```
 
 Your config contains a **seed** — a secret string that never leaves the server. The actual URL key is **derived** from the seed by the server. To get it:
@@ -171,12 +168,11 @@ process.stdin.on('end', () => {
 
 ## Global Settings
 
-```typescript
-// Default timeout for all event commands (ms)
-eventTimeoutMs: 30_000,
-
-// Purge log entries older than this (ms). Default: 30 days
-eventLogPurgeMs: 2_592_000_000,
+```json
+{
+  "eventTimeoutMs": 30000,
+  "eventLogPurgeMs": 2592000000
+}
 ```
 
 ## Monitoring
@@ -193,7 +189,7 @@ grep '"matched":false' logs/event-log.jsonl
 
 ## Example: Notion Webhook Integration
 
-1. **Configure the event** in `jeeves.config.ts` (see Configuration above)
+1. **Configure the event** in `your config file` (see Configuration above)
 2. **Create a scoped key** for the webhook
 3. **Register the webhook URL** in Notion:
    - Settings → Connections → Add a connection

--- a/packages/service/guides/exports.md
+++ b/packages/service/guides/exports.md
@@ -62,14 +62,16 @@ PDF generation uses [**Puppeteer**](https://github.com/puppeteer/puppeteer) with
 ### Requirements
 
 - **Chrome/Chromium** must be installed on the server
-- **`chromePath`** must point to the executable in `jeeves.config.ts`
+- **`chromePath`** must point to the executable in `your config file`
 - **`_internal` key** must be configured (Puppeteer uses it to authenticate)
 
-```typescript
-chromePath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-keys: {
-  _internal: 'random-seed-string',  // Required for PDF/DOCX export
-},
+```json
+{
+  "chromePath": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  "keys": {
+    "_internal": "random-seed-string"
+  }
+}
 ```
 
 ### What you see is what you get
@@ -111,13 +113,7 @@ Mermaid diagrams (`.mmd` files) can be exported as SVG, PNG, or PDF via the [Mer
 
 ### Requirements
 
-- **Mermaid CLI** must be installed (via npm)
-- **`mermaidCliPath`** must point to the `mmdc` binary in `jeeves.config.ts`
-- **Puppeteer/Chrome** is required by Mermaid CLI for rendering
-
-```typescript
-mermaidCliPath: '/usr/local/bin/mmdc',
-```
+Mermaid CLI is bundled as a direct dependency (`@mermaid-js/mermaid-cli`) — no separate installation or configuration needed. Chrome/Chromium is required for rendering.
 
 ### Export endpoint
 
@@ -139,12 +135,14 @@ PlantUML uses a **fallback rendering pipeline** — each method is tried in orde
 
 ### Configuration
 
-```typescript
-plantuml: {
-  jarPath: '/opt/plantuml/plantuml.jar',   // Local jar path (optional)
-  javaPath: '/usr/bin/java',               // Java binary (optional, defaults to 'java')
-  servers: ['https://internal.plantuml.example.com/plantuml'],  // Private servers (optional)
-},
+```json
+{
+  "plantuml": {
+    "jarPath": "/opt/plantuml/plantuml.jar",
+    "javaPath": "/usr/bin/java",
+    "servers": ["https://internal.plantuml.example.com/plantuml"]
+  }
+}
 ```
 
 If `plantuml` is omitted entirely, only the public community server is used.
@@ -219,7 +217,7 @@ Directories can be downloaded as ZIP archives. The header shows a ZIP download o
 
 The `maxZipSizeMb` config setting (default: 100 MB) prevents accidentally zipping enormous directories:
 
-```typescript
+```
 maxZipSizeMb: 100,  // Refuse ZIP for directories larger than this
 ```
 

--- a/packages/service/guides/setup.md
+++ b/packages/service/guides/setup.md
@@ -2,70 +2,121 @@
 
 ## Prerequisites
 
-- **Node.js** ≥ 18
+- **Node.js** ≥ 20
 - **Chrome or Chromium** — required for PDF export (Puppeteer uses it headlessly)
-- **A domain or IP** where the server will be accessible (for Google OAuth callbacks)
 
 ## Installation
 
 ```bash
-git clone https://github.com/karmaniverous/jeeves-server.git
-cd jeeves-server
-npm install
+npm install -g @karmaniverous/jeeves-server
 ```
+
+The `postinstall` script automatically downloads the PlantUML jar for local diagram rendering.
 
 ## Configuration
 
-Jeeves Server uses a **TypeScript configuration file** validated at startup by a [Zod](https://github.com/colinhacks/zod) schema. The schema at `src/config/schema.ts` is the single source of truth — all types are derived from it.
-
-### Create your config
+Jeeves Server uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) for configuration. Create a config file in any supported format:
 
 ```bash
-cp jeeves.config.template.ts jeeves.config.ts
+# JSON (recommended for simplicity)
+jeeves-server.config.json
+
+# YAML
+jeeves-server.config.yaml
+
+# TypeScript (for type checking during authoring)
+jeeves-server.config.ts
+
+# Or any cosmiconfig-supported format
 ```
 
-Edit `jeeves.config.ts` with your values. This file is **gitignored** — it contains secrets and is never committed.
+The server searches for config files starting from its working directory and walking up. You can also specify an explicit path:
 
-### Config structure
-
-```typescript
-import type { JeevesConfig } from './src/config/schema.js';
-
-export default {
-  port: 1934,
-  chromePath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-  auth: { ... },
-  insiders: { ... },
-  keys: { ... },
-  events: { ... },
-} satisfies JeevesConfig;
+```bash
+jeeves-server start --config /path/to/jeeves-server.config.json
 ```
 
-The `satisfies` keyword gives you type checking without losing literal types — your editor will autocomplete and validate as you type.
+### Config structure (JSON)
+
+```json
+{
+  "port": 1934,
+  "chromePath": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  "auth": {
+    "modes": ["keys", "google"],
+    "google": {
+      "clientId": "your-google-client-id",
+      "clientSecret": "your-google-client-secret"
+    },
+    "sessionSecret": "random-session-signing-secret"
+  },
+  "scopes": {
+    "restricted": {
+      "allow": ["/d/projects/*"],
+      "deny": ["/d/projects/secret/*"]
+    }
+  },
+  "insiders": {
+    "alice@example.com": {},
+    "contractor@example.com": { "scopes": "restricted" }
+  },
+  "keys": {
+    "_internal": "random-hex-seed-for-pdf-export",
+    "_plugin": "random-hex-seed-for-openclaw-plugin",
+    "primary": "random-hex-seed-for-api-access",
+    "webhook-notion": {
+      "key": "random-hex-seed",
+      "scopes": ["/event"]
+    }
+  },
+  "events": {},
+  "watcherUrl": "http://localhost:1936",
+  "runnerUrl": "http://127.0.0.1:1937"
+}
+```
+
+### Environment variable substitution
+
+String values in the config support `${VAR_NAME}` substitution from `process.env`:
+
+```json
+{
+  "auth": {
+    "google": {
+      "clientId": "${GOOGLE_CLIENT_ID}",
+      "clientSecret": "${GOOGLE_CLIENT_SECRET}"
+    }
+  }
+}
+```
+
+### Validating your config
+
+```bash
+jeeves-server config validate [--config <path>]
+```
+
+This loads and validates the config against the Zod schema, reporting any errors. Use `config show` to see the fully resolved configuration with all derived keys and scope assignments.
 
 ### Platform-specific settings
 
 **Windows** — drives are auto-discovered; no `roots` config needed:
-```typescript
-chromePath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+```json
+{ "chromePath": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" }
 ```
 
 **Linux** — configure filesystem roots for the file browser:
-```typescript
-chromePath: '/usr/bin/chromium-browser',
-roots: {
-  home: '/home',
-  projects: '/opt/projects',
-},
-mermaidCliPath: '/opt/mermaid-cli',  // optional
-plantuml: {                          // optional
-  jarPath: '/opt/plantuml/plantuml.jar',
-  javaPath: '/usr/bin/java',         // defaults to 'java' on PATH
-  servers: [],                       // private servers; community server always appended
-},
+```json
+{
+  "chromePath": "/usr/bin/chromium-browser",
+  "roots": {
+    "home": "/home",
+    "projects": "/opt/projects"
+  }
+}
 ```
 
-On Windows, `roots` is ignored. On Linux, if omitted, it defaults to `{ root: '/' }`.
+On Windows, `roots` is ignored. On Linux, if omitted, it defaults to `{ "root": "/" }`.
 
 ### Config is immutable at runtime
 
@@ -77,16 +128,17 @@ Once the server starts, the config is loaded once and never written to. Mutable 
 
 Jeeves Server supports two authentication methods, configured via `auth.modes`:
 
-```typescript
-auth: {
-  modes: ['google', 'keys'],  // Active modes, in priority order
-  // ...
+```json
+{
+  "auth": {
+    "modes": ["google", "keys"]
+  }
 }
 ```
 
 You can enable one or both. The order matters — modes are checked in the order listed.
 
-### Google OAuth (`'google'`)
+### Google OAuth (`"google"`)
 
 **Best for:** Teams where insiders log in via browser.
 
@@ -104,76 +156,85 @@ Users authenticate with their Google account. The server checks their email agai
 4. Authorized redirect URI: `https://your-domain.com/auth/google/callback`
 5. Copy the client ID and client secret into your config
 
-**Session secret generation:**
-```bash
-node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-```
-
-### Key-Based Auth (`'keys'`)
+### Key-Based Auth (`"keys"`)
 
 **Best for:** Headless access, bot integrations, simple setups without Google.
 
-Users authenticate by appending `?key=<value>` to any URL. The server derives keys from configured seeds using HMAC-SHA256 and checks the provided key against all known derived keys.
+Users authenticate by appending `?key=<value>` to any URL. The server derives keys from configured seeds using HMAC-SHA256.
 
 **Requirements when enabled:**
 - At least one entry in `keys`
 
-**How keys work:** You configure a **seed** (a random secret string). The server derives the actual insider key from it via HMAC. You never put the derived key in the config — only the seed. To get the derived key for use in URLs:
+**How keys work:** You configure a **seed** (a random secret string). The server derives the actual key from it via HMAC. You never put the derived key in the config — only the seed. To get the derived key:
 
 ```bash
-# Via the API (requires X-API-Key header with any seed)
 curl -H "X-API-Key: <seed>" https://your-domain.com/insider-key
 ```
 
 ### Both Modes Together
 
-```typescript
-auth: {
-  modes: ['keys', 'google'],  // Keys checked first
-}
-```
-
-When both are active:
-- Browser users can log in with Google for a session-based experience
-- Bots and scripts can use `?key=` for stateless access
-- Both methods work on every endpoint
-
-### Choosing a Mode
+When both are active, browser users log in with Google, and bots/scripts use `?key=` for stateless access. Both methods work on every endpoint.
 
 | Scenario | Recommended |
 |----------|-------------|
-| Team of humans accessing via browser | `['google']` |
-| Bot/script access only | `['keys']` |
-| Humans + bots on the same server | `['google', 'keys']` |
-| Quick local setup, no Google credentials | `['keys']` |
+| Team of humans accessing via browser | `["google"]` |
+| Bot/script access only | `["keys"]` |
+| Humans + bots on the same server | `["google", "keys"]` |
+| Quick local setup, no Google credentials | `["keys"]` |
+
+---
+
+## Named Access Scopes
+
+Define reusable scope policies at the top level, then reference them by name from insiders, keys, or the outsider policy:
+
+```json
+{
+  "scopes": {
+    "engineering": {
+      "allow": ["/d/repos/*", "/d/docs/*"],
+      "deny": ["/d/docs/hr/*"]
+    },
+    "readonly-projects": {
+      "allow": ["/d/projects/*"]
+    }
+  },
+  "insiders": {
+    "dev@example.com": { "scopes": "engineering" },
+    "contractor@example.com": {
+      "scopes": "readonly-projects",
+      "deny": ["/d/projects/secret/*"]
+    }
+  }
+}
+```
+
+Named scopes are **atomic** — composition happens at the point of use. An insider or key referencing a named scope can add extra `allow` and `deny` patterns that merge on top of the named scope's rules.
+
+Scopes can also be specified inline (without named references) using the same formats as before:
+
+```json
+{ "scopes": ["/d/projects/*"] }
+{ "scopes": { "allow": ["/d/*"], "deny": ["/d/secrets/*"] } }
+```
 
 ---
 
 ## Insiders
 
-The `insiders` map defines **who** has full browsing access. Each entry is an email address with optional path scopes:
+The `insiders` map defines **who** has full browsing access:
 
-```typescript
-insiders: {
-  // Full access
-  'alice@example.com': {},
-
-  // Restricted to specific paths (allow-only)
-  'contractor@example.com': {
-    scopes: ['/d/projects/client-x/*'],
-  },
-
-  // Broad access with cutouts (allow/deny)
-  'team-member@example.com': {
-    scopes: {
-      allow: ['/d/*'],
-      deny: ['/d/secrets/*', '/d/.private/*'],
-    },
-  },
-},
+```json
+{
+  "insiders": {
+    "alice@example.com": {},
+    "contractor@example.com": { "scopes": "restricted" },
+    "team@example.com": {
+      "scopes": { "allow": ["/d/*"], "deny": ["/d/secrets/*"] }
+    }
+  }
+}
 ```
-
-With Google auth, insiders log in via OAuth and the server checks their email. With key auth, each insider gets a derived URL key.
 
 See the [Insiders, Outsiders & Sharing](sharing.md) guide for the full access model.
 
@@ -181,22 +242,20 @@ See the [Insiders, Outsiders & Sharing](sharing.md) guide for the full access mo
 
 ## Keys
 
-The `keys` map defines **named API keys** for machine access:
+The `keys` map defines **named API keys** for machine and human access:
 
-```typescript
-keys: {
-  // Unscoped — full access to all paths
-  primary: 'a-random-64-char-hex-string',
-
-  // Scoped — restricted to specific paths
-  'webhook-notion': {
-    key: 'another-random-hex-string',
-    scopes: ['/event'],
-  },
-
-  // Reserved: internal server operations (Puppeteer export)
-  _internal: 'yet-another-random-hex-string',
-},
+```json
+{
+  "keys": {
+    "primary": "a-random-64-char-hex-string",
+    "webhook-notion": {
+      "key": "another-random-hex-string",
+      "scopes": ["/event"]
+    },
+    "_internal": "seed-for-pdf-export",
+    "_plugin": "seed-for-openclaw-plugin"
+  }
+}
 ```
 
 **Generate seeds with:**
@@ -204,110 +263,81 @@ keys: {
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-### The `_internal` key
+### Reserved keys
 
-The `_internal` key is reserved for the server's own use — specifically, Puppeteer uses it to authenticate when rendering PDFs and DOCX files. It **must not** have scopes (enforced by the schema).
+| Key | Purpose | Scopes |
+|-----|---------|--------|
+| `_internal` | Puppeteer uses this to authenticate when rendering PDFs/DOCX. **Required for export.** | Must be unscoped |
+| `_plugin` | OpenClaw plugin authentication. See [OpenClaw Integration](../../openclaw/guides/openclaw-integration.md). | Must be unscoped |
 
-If you don't configure `_internal`, PDF/DOCX export will not work.
-
-### Key names
-
-Key names are used for logging and identification. Choose meaningful names: `primary`, `webhook-notion`, `ci-bot`, etc.
+Both reserved keys are enforced unscoped by the Zod schema.
 
 ---
 
 ## Event Gateway
 
-The event gateway receives webhooks at `POST /event`, validates them against JSON Schema rules, and dispatches matched events to shell commands via a durable JSONL queue.
-
-```typescript
-events: {
-  'notion-page-update': {
-    // JSON Schema to match against incoming body
-    schema: {
-      type: 'object',
-      properties: { type: { const: 'page.content_updated' } },
-      required: ['type'],
-    },
-    // Command to execute when matched
-    cmd: 'node /path/to/handler.js',
-    // Optional: transform body before passing to command
-    map: {
-      pageId: { '$': { method: '$.lib._.get', params: ['$.input', 'data.page_id'] } },
-    },
-    // Optional: override default timeout
-    timeoutMs: 60000,
-  },
-},
-```
-
-Webhook callers authenticate with a scoped key:
-```bash
-curl -X POST "https://your-domain.com/event?key=<webhook-key>" \
-  -H "Content-Type: application/json" \
-  -d '{"type": "page.content_updated", "data": {"page_id": "abc123"}}'
-```
+See the [Event Gateway](event-gateway.md) guide for full configuration and usage.
 
 ---
 
-## Building
+## Optional Integrations
 
-```bash
-# Full build (server TypeScript + React client)
-npm run build                                      # Compiles server → dist/
-cd client && npx vite build --outDir ../dist/client && cd ..  # Builds React SPA → dist/client/
+### jeeves-watcher (Semantic Search)
+
+When `watcherUrl` is configured, the server proxies semantic search queries to [jeeves-watcher](https://github.com/karmaniverous/jeeves-watcher) and provides a search UI in the header, with filter facets and scope-aware result filtering.
+
+```json
+{ "watcherUrl": "http://localhost:1936" }
 ```
 
-> ⚠️ `npm run build` deletes the entire `dist/` directory (including `dist/client/`). Always rebuild the client after the server.
+### jeeves-runner (Process Dashboard)
+
+When `runnerUrl` is configured, the server proxies runner API calls for the process dashboard UI.
+
+```json
+{ "runnerUrl": "http://127.0.0.1:1937" }
+```
+
+### PlantUML
+
+Mermaid is bundled as a direct dependency — no configuration needed. PlantUML uses a fallback pipeline:
+
+1. **Local Java jar** (downloaded automatically via `postinstall`) — fastest, supports `!include`
+2. **Configured PlantUML servers** — private instances, tried in order
+3. **Public community server** (`plantuml.com`) — always appended as last resort
+
+```json
+{
+  "plantuml": {
+    "jarPath": "/opt/plantuml/plantuml.jar",
+    "javaPath": "/usr/bin/java",
+    "servers": ["https://internal.plantuml.example.com/plantuml"]
+  }
+}
+```
+
+If `plantuml` is omitted entirely, only the community server is used.
 
 ---
 
-## Running
+## Config Reference
 
-```bash
-node dist/server.js
-```
-
-### As a Windows service
-
-```bash
-nssm install JeevesServer "node" "/path/to/dist/server.js"
-nssm start JeevesServer
-```
-
-### Health check
-
-```
-GET /health
-```
-
-Returns `200 OK` with no authentication required.
-
----
-
-## File Layout
-
-```
-jeeves-server/
-├── jeeves.config.ts          # Your config (gitignored)
-├── jeeves.config.template.ts # Config template (committed)
-├── state.json                # Runtime state (gitignored, auto-managed)
-├── src/                      # Server source (TypeScript)
-│   ├── config/
-│   │   ├── schema.ts         # Zod schema (source of truth)
-│   │   ├── index.ts          # Config loader (jiti for TS)
-│   │   └── types.ts          # Runtime types
-│   ├── auth/                 # Google OAuth + key verification
-│   ├── routes/               # Fastify route handlers
-│   ├── services/             # Export, markdown, event queue
-│   └── server.ts             # Entry point
-├── client/                   # React SPA source
-│   └── src/
-│       ├── pages/            # FileBrowser, FileViewer, About
-│       ├── components/       # Header, dropdowns, viewers
-│       └── lib/              # API client, auth, theme
-├── dist/                     # Compiled output (gitignored)
-│   ├── server.js             # Compiled server
-│   └── client/               # Built React SPA
-└── guides/                   # Documentation
-```
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port` | number | `1934` | Server port |
+| `chromePath` | string | *required* | Path to Chrome/Chromium executable |
+| `auth` | object | *required* | Authentication configuration |
+| `scopes` | object | `{}` | Named scope definitions |
+| `insiders` | object | `{}` | Email → insider entry map |
+| `keys` | object | `{}` | Named key entries |
+| `events` | object | `{}` | Event gateway schemas |
+| `eventTimeoutMs` | number | `30000` | Default event command timeout |
+| `eventLogPurgeMs` | number | `2592000000` | Event log retention (default: 30 days) |
+| `maxZipSizeMb` | number | `100` | Max directory size for ZIP export |
+| `roots` | object | — | Linux filesystem roots (ignored on Windows) |
+| `watcherUrl` | string | — | jeeves-watcher API URL for semantic search |
+| `runnerUrl` | string | — | jeeves-runner API URL for process dashboard |
+| `plantuml` | object | — | PlantUML rendering config |
+| `diagramCachePath` | string | `.diagram-cache` | Cached rendered diagram directory |
+| `outsiderPolicy` | scopes | — | Global outsider sharing constraints |
+| `mermaidCliPath` | string | — | **Deprecated.** Mermaid is now bundled. |

--- a/packages/service/guides/sharing.md
+++ b/packages/service/guides/sharing.md
@@ -10,11 +10,11 @@ An insider is an **authenticated user** on the server. Depending on their config
 
 Anyone listed in the `insiders` map in your config:
 
-```typescript
-insiders: {
-  'alice@example.com': {},
-  'bob@example.com': { scopes: ['/d/projects/*'] },
-},
+```json
+{
+  "alice@example.com": {},
+  "bob@example.com": { "scopes": ["/d/projects/*"] }
+}
 ```
 
 ### How insiders authenticate
@@ -155,8 +155,8 @@ Use rotation when you need to revoke all shared links at once (e.g., a contracto
 
 In addition to insider-generated keys, the server supports **named machine keys** for programmatic access:
 
-```typescript
-keys: {
+```json
+"keys": {
   primary: 'random-seed-string',
   'webhook-notion': { key: 'another-seed', scopes: ['/event'] },
   _internal: 'internal-seed',


### PR DESCRIPTION
Full documentation sync pass for v3.0.0 implementation:\n\n- Update root README for monorepo + CLI + cosmiconfig\n- Update setup/deploy/api/sharing/exports/event-gateway guides to match current endpoints and config schema\n- Add package-level READMEs for service + OpenClaw plugin\n- Clean knip configuration so knip runs clean\n