### PR TITLE
fix: Rendered tab persists when switching to Raw on watcher-rendered files

### DIFF
--- a/packages/service/client/src/components/TabBar.tsx
+++ b/packages/service/client/src/components/TabBar.tsx
@@ -30,7 +30,7 @@ export function TabBar({
 }: TabBarProps) {
   if (!file && !loading) return null;
 
-  const renderable = file ? isRenderable(file) : isRenderableExt(reqPath);
+  const renderable = (fileRendered ? isRenderable(fileRendered) : false) || (file ? isRenderable(file) : isRenderableExt(reqPath));
   const activeTab = renderable ? viewTab : 'raw';
 
   return (


### PR DESCRIPTION
TabBar checked only file.type for renderability, which could be the raw response (type: text) instead of the rendered response (type: markdown). Now checks fileRendered first, so watcher-rendered JSON files keep the Rendered tab visible when switching to Raw.