### PR TITLE
fix: prevent full data reload on tab switch

### DIFF
--- a/packages/service/client/src/hooks/useFileData.ts
+++ b/packages/service/client/src/hooks/useFileData.ts
@@ -56,9 +56,11 @@ export function useFileData(reqPath: string, searchParams: URLSearchParams) {
     }
   }, []);
 
+  // Only reload data when the path changes, not when tab params change
   useEffect(() => {
     void loadData(reqPath, searchParams);
-  }, [loadData, reqPath, searchParams]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadData, reqPath]);
 
   const handleSave = async (content: string) => {
     await saveFile(reqPath, content);


### PR DESCRIPTION
useFileData effect depended on searchParams, so switching tabs (which updates ?tab=raw in the URL) triggered a full data reload — resetting fileRendered to null and causing the Rendered tab to disappear on watcher-rendered files. Now the effect only depends on reqPath.