### PR TITLE
feat: explicit scope overrides take precedence over named scopes

### DIFF
--- a/packages/service/src/auth/keys.test.ts
+++ b/packages/service/src/auth/keys.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for scope override precedence in key verification.
+ *
+ * Verifies the three-tier evaluation order:
+ * 1. explicitDeny → DENIED (overrides named allow)
+ * 2. explicitAllow → ALLOWED (overrides named deny)
+ * 3. Standard allow AND NOT deny
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { _pathMatchesScopes as pathMatchesScopes } from './keys.js';
+
+describe('pathMatchesScopes', () => {
+  it('allows a path matching allow and not deny', () => {
+    expect(
+      pathMatchesScopes('/d/projects/foo', {
+        allow: ['/d/projects/**'],
+        deny: [],
+        explicitAllow: [],
+        explicitDeny: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('denies a path not matching any allow', () => {
+    expect(
+      pathMatchesScopes('/d/secrets/foo', {
+        allow: ['/d/projects/**'],
+        deny: [],
+        explicitAllow: [],
+        explicitDeny: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('denies a path matching a deny pattern', () => {
+    expect(
+      pathMatchesScopes('/d/projects/secret/foo', {
+        allow: ['/d/projects/**'],
+        deny: ['/d/projects/secret/**'],
+        explicitAllow: [],
+        explicitDeny: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('explicit allow overrides named deny', () => {
+    expect(
+      pathMatchesScopes('/j/domains/projects/jill/doc.md', {
+        allow: ['/j/domains/projects/**'],
+        deny: ['/j/domains/projects/jill/**'],
+        explicitAllow: ['/j/domains/projects/jill/**'],
+        explicitDeny: [],
+      }),
+    ).toBe(true);
+  });
+
+  it('explicit deny overrides named allow', () => {
+    expect(
+      pathMatchesScopes('/d/repos/secret/code.ts', {
+        allow: ['/d/repos/**'],
+        deny: [],
+        explicitAllow: [],
+        explicitDeny: ['/d/repos/secret/**'],
+      }),
+    ).toBe(false);
+  });
+
+  it('explicit deny takes precedence over explicit allow', () => {
+    expect(
+      pathMatchesScopes('/d/repos/secret/code.ts', {
+        allow: ['/d/repos/**'],
+        deny: [],
+        explicitAllow: ['/d/repos/secret/**'],
+        explicitDeny: ['/d/repos/secret/**'],
+      }),
+    ).toBe(false);
+  });
+
+  it('path not in any scope is denied even with explicit allow on different path', () => {
+    expect(
+      pathMatchesScopes('/totally/elsewhere', {
+        allow: ['/d/projects/**'],
+        deny: [],
+        explicitAllow: ['/j/domains/projects/jill/**'],
+        explicitDeny: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('Robert/Jill scenario: projects + no-private + explicit jill allow', () => {
+    // Named scopes: projects (allow /j/domains/projects/**) + no-private (deny /j/domains/projects/jill/**)
+    // Explicit: allow /j/domains/projects/jill/**
+    const scopes = {
+      allow: ['/j/domains/projects/**'],
+      deny: ['/j/domains/projects/jill/**'],
+      explicitAllow: ['/j/domains/projects/jill/**'],
+      explicitDeny: [],
+    };
+
+    // Jill's project should be accessible (explicit allow overrides named deny)
+    expect(
+      pathMatchesScopes('/j/domains/projects/jill/thesis.md', scopes),
+    ).toBe(true);
+
+    // Other projects should work normally
+    expect(
+      pathMatchesScopes('/j/domains/projects/jeeves-server/readme.md', scopes),
+    ).toBe(true);
+
+    // Other private projects (if they existed) would still be denied
+    // (only jill is explicitly allowed)
+  });
+});

--- a/packages/service/src/auth/keys.ts
+++ b/packages/service/src/auth/keys.ts
@@ -44,12 +44,29 @@ function pathMatchesPatterns(requestPath: string, patterns: string[]): boolean {
 
 /**
  * Check whether a request path matches normalized scopes (allow/deny).
- * Path must match at least one allow rule AND NOT match any deny rule.
+ *
+ * Evaluation order (explicit overrides take highest precedence):
+ * 1. If explicitDeny matches → DENIED (overrides named allow)
+ * 2. If explicitAllow matches → ALLOWED (overrides named deny)
+ * 3. Path must match at least one allow rule AND NOT match any deny rule.
  */
 function pathMatchesScopes(
   requestPath: string,
   scopes: NormalizedScopes,
 ): boolean {
+  // Explicit overrides take precedence over named scope patterns
+  if (
+    scopes.explicitDeny.length > 0 &&
+    pathMatchesPatterns(requestPath, scopes.explicitDeny)
+  )
+    return false;
+  if (
+    scopes.explicitAllow.length > 0 &&
+    pathMatchesPatterns(requestPath, scopes.explicitAllow)
+  )
+    return true;
+
+  // Standard evaluation: allow AND NOT deny
   if (!pathMatchesPatterns(requestPath, scopes.allow)) return false;
   if (scopes.deny.length > 0 && pathMatchesPatterns(requestPath, scopes.deny))
     return false;

--- a/packages/service/src/config/loadConfig.test.ts
+++ b/packages/service/src/config/loadConfig.test.ts
@@ -147,7 +147,12 @@ describe('loadConfig', () => {
     const config = await loadConfig(configPath);
     expect(
       config.resolvedInsiders.find((i) => i.email === 'a@example.com')?.scopes,
-    ).toEqual({ allow: ['/docs/**'], deny: [] });
+    ).toEqual({
+      allow: ['/docs/**'],
+      deny: [],
+      explicitAllow: [],
+      explicitDeny: [],
+    });
   });
 });
 

--- a/packages/service/src/config/resolve.test.ts
+++ b/packages/service/src/config/resolve.test.ts
@@ -25,13 +25,20 @@ describe('normalizeScopes', () => {
   });
 
   it('wraps a string in allow array', () => {
-    expect(normalizeScopes('/docs')).toEqual({ allow: ['/docs'], deny: [] });
+    expect(normalizeScopes('/docs')).toEqual({
+      allow: ['/docs'],
+      deny: [],
+      explicitAllow: [],
+      explicitDeny: [],
+    });
   });
 
   it('wraps an array as allow', () => {
     expect(normalizeScopes(['/a', '/b'])).toEqual({
       allow: ['/a', '/b'],
       deny: [],
+      explicitAllow: [],
+      explicitDeny: [],
     });
   });
 
@@ -39,12 +46,18 @@ describe('normalizeScopes', () => {
     expect(normalizeScopes({ deny: ['/secret'] })).toEqual({
       allow: ['/**'],
       deny: ['/secret'],
+      explicitAllow: [],
+      explicitDeny: [],
     });
   });
 
   it('passes through complete object', () => {
     const scopes = { allow: ['/a'], deny: ['/b'] };
-    expect(normalizeScopes(scopes)).toEqual(scopes);
+    expect(normalizeScopes(scopes)).toEqual({
+      ...scopes,
+      explicitAllow: [],
+      explicitDeny: [],
+    });
   });
 });
 
@@ -65,7 +78,12 @@ describe('resolveKeys', () => {
     );
     expect(result[0].name).toBe('scoped');
     expect(result[0].seed).toBe('seed456');
-    expect(result[0].scopes).toEqual({ allow: ['/docs'], deny: [] });
+    expect(result[0].scopes).toEqual({
+      allow: ['/docs'],
+      deny: [],
+      explicitAllow: [],
+      explicitDeny: [],
+    });
   });
 
   it('handles mixed entries', () => {
@@ -78,7 +96,12 @@ describe('resolveKeys', () => {
     );
     expect(result).toHaveLength(2);
     expect(result[0].scopes).toBe(null);
-    expect(result[1].scopes).toEqual({ allow: ['/x'], deny: ['/y'] });
+    expect(result[1].scopes).toEqual({
+      allow: ['/x'],
+      deny: ['/y'],
+      explicitAllow: [],
+      explicitDeny: [],
+    });
   });
 });
 
@@ -128,6 +151,8 @@ describe('resolveNamedScopes', () => {
     expect(resolveNamedScopes(named, 'restricted')).toEqual({
       allow: ['/**'],
       deny: ['/secret'],
+      explicitAllow: [],
+      explicitDeny: [],
     });
   });
 
@@ -144,6 +169,8 @@ describe('resolveNamedScopes', () => {
     ).toEqual({
       allow: ['/**', '/extra'],
       deny: ['/secret', '/vc/**', '/more'],
+      explicitAllow: ['/extra'],
+      explicitDeny: ['/more'],
     });
   });
 
@@ -152,6 +179,8 @@ describe('resolveNamedScopes', () => {
     expect(resolveNamedScopes(named, '/docs')).toEqual({
       allow: ['/docs'],
       deny: [],
+      explicitAllow: [],
+      explicitDeny: [],
     });
   });
 });

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -27,13 +27,22 @@ import type {
  */
 export function normalizeScopes(raw: unknown): NormalizedScopes | null {
   if (raw === undefined || raw === null) return null;
-  if (typeof raw === 'string') return { allow: [raw], deny: [] };
-  if (Array.isArray(raw)) return { allow: raw as string[], deny: [] };
+  if (typeof raw === 'string')
+    return { allow: [raw], deny: [], explicitAllow: [], explicitDeny: [] };
+  if (Array.isArray(raw))
+    return {
+      allow: raw as string[],
+      deny: [],
+      explicitAllow: [],
+      explicitDeny: [],
+    };
   if (typeof raw === 'object') {
     const obj = raw as { allow?: string[]; deny?: string[] };
     return {
       allow: obj.allow ?? ['/**'],
       deny: obj.deny ?? [],
+      explicitAllow: [],
+      explicitDeny: [],
     };
   }
   return null;
@@ -56,6 +65,8 @@ export function resolveNamedScopes(
       return {
         allow: overrides.allow ?? ['/**'],
         deny: overrides.deny ?? [],
+        explicitAllow: overrides.allow ?? [],
+        explicitDeny: overrides.deny ?? [],
       };
     }
     return null;
@@ -91,6 +102,8 @@ export function resolveNamedScopes(
     return {
       allow: allow.length > 0 ? allow : ['/**'],
       deny,
+      explicitAllow: overrides?.allow ?? [],
+      explicitDeny: overrides?.deny ?? [],
     };
   }
 
@@ -99,6 +112,8 @@ export function resolveNamedScopes(
   if (!normalized) return null;
   if (overrides?.allow) normalized.allow.push(...overrides.allow);
   if (overrides?.deny) normalized.deny.push(...overrides.deny);
+  normalized.explicitAllow = overrides?.allow ?? [];
+  normalized.explicitDeny = overrides?.deny ?? [];
   return normalized;
 }
 

--- a/packages/service/src/config/types.ts
+++ b/packages/service/src/config/types.ts
@@ -11,10 +11,19 @@ export type { AuthMode, JeevesConfig };
 /**
  * Normalized scopes — always resolved to \{ allow, deny \} form.
  * null = unrestricted access.
+ *
+ * Explicit overrides take precedence over named scope patterns:
+ * 1. If explicitDeny matches → DENIED (overrides named allow)
+ * 2. If explicitAllow matches → ALLOWED (overrides named deny)
+ * 3. Otherwise: normal allow AND NOT deny evaluation
  */
 export interface NormalizedScopes {
   allow: string[];
   deny: string[];
+  /** Explicit allow patterns from the insider/key entry — override named scope denies. */
+  explicitAllow: string[];
+  /** Explicit deny patterns from the insider/key entry — override named scope allows. */
+  explicitDeny: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds three-tier scope evaluation so explicit `allow`/`deny` patterns on insider/key entries take precedence over named scope patterns.

**Evaluation order in `pathMatchesScopes`:**
1. `explicitDeny` matches → **DENIED** (overrides named allow)
2. `explicitAllow` matches → **ALLOWED** (overrides named deny)
3. Standard `allow AND NOT deny` on merged named scopes

## Motivation

Enables composable named scopes with surgical overrides. For example, an insider can reference `["projects", "no-private"]` named scopes but add an explicit `allow` to punch through the deny for a specific project they should access.

## Changes

- **`types.ts`** — Added `explicitAllow` and `explicitDeny` fields to `NormalizedScopes`
- **`resolve.ts`** — `resolveNamedScopes` and `normalizeScopes` populate explicit fields separately from merged named scope patterns
- **`keys.ts`** — `pathMatchesScopes` checks explicit overrides first
- **`keys.test.ts`** — New test file covering all override scenarios
- Updated existing test expectations to include new fields

## Verification

All 132 tests pass. Build, typecheck, lint, and knip all clean.
