### PR TITLE
Add configurable host bind + metaUrl service probe

### DIFF
--- a/packages/openclaw/src/cli.ts
+++ b/packages/openclaw/src/cli.ts
@@ -10,7 +10,7 @@
  *   - OPENCLAW_HOME env var (path to .openclaw directory)
  *   - Default: ~/.openclaw/openclaw.json
  *
- * @module cli
+ * @packageDocumentation
  */
 
 import {

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -6,7 +6,7 @@
  * authenticated requests to jeeves-server. Generic helpers (ok, fail,
  * connectionFail, fetchJson, etc.) are imported from `@karmaniverous/jeeves`.
  *
- * @module helpers
+ * @packageDocumentation
  */
 
 import { createHmac } from 'node:crypto';

--- a/packages/service/src/cli/commands/config.ts
+++ b/packages/service/src/cli/commands/config.ts
@@ -27,6 +27,7 @@ export function registerConfigCommand(cli: Command): void {
         const cfg = await loadConfig(options.config);
         console.log('\u2713 Configuration valid');
         console.log(`  Port: ${String(cfg.port)}`);
+        console.log(`  Host: ${cfg.host}`);
         console.log(`  Auth modes: ${cfg.authModes.join(', ')}`);
         console.log(`  Keys: ${String(cfg.resolvedKeys.length)}`);
         console.log(`  Insiders: ${String(cfg.resolvedInsiders.length)}`);
@@ -35,6 +36,7 @@ export function registerConfigCommand(cli: Command): void {
         );
         if (cfg.watcherUrl) console.log(`  Watcher: ${cfg.watcherUrl}`);
         if (cfg.runnerUrl) console.log(`  Runner: ${cfg.runnerUrl}`);
+        if (cfg.metaUrl) console.log(`  Meta: ${cfg.metaUrl}`);
       } catch (error) {
         console.error('\u2717 Configuration invalid');
         console.error(error instanceof Error ? error.message : String(error));
@@ -53,6 +55,7 @@ export function registerConfigCommand(cli: Command): void {
         console.log('');
         console.log('Server:');
         console.log(`  port: ${String(cfg.port)}`);
+        console.log(`  host: ${cfg.host}`);
         console.log(`  chromePath: ${cfg.chromePath}`);
         if (cfg.roots) {
           console.log(`  roots: ${JSON.stringify(cfg.roots)}`);
@@ -78,6 +81,7 @@ export function registerConfigCommand(cli: Command): void {
         console.log('Integrations:');
         console.log(`  watcherUrl: ${cfg.watcherUrl ?? 'not configured'}`);
         console.log(`  runnerUrl: ${cfg.runnerUrl ?? 'not configured'}`);
+        console.log(`  metaUrl: ${cfg.metaUrl ?? 'not configured'}`);
         console.log('');
         console.log('Events:');
         const eventNames = Object.keys(cfg.events);

--- a/packages/service/src/config/resolve.test.ts
+++ b/packages/service/src/config/resolve.test.ts
@@ -236,6 +236,8 @@ describe('buildRuntimeConfig', () => {
   it('constructs correct path fields', () => {
     const config = {
       port: 1934,
+      host: '0.0.0.0',
+      metaUrl: 'http://127.0.0.1:1938',
       eventTimeoutMs: 30000,
       eventLogPurgeMs: 2592000000,
       maxZipSizeMb: 100,

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -250,6 +250,7 @@ export function buildRuntimeConfig(
 
   return {
     port: config.port,
+    host: config.host,
     eventTimeoutMs: config.eventTimeoutMs,
     eventLogPurgeMs: config.eventLogPurgeMs,
     maxZipSizeMb: config.maxZipSizeMb,
@@ -285,6 +286,7 @@ export function buildRuntimeConfig(
     internalInsiderKey: deriveInternalKey(resolvedKeys),
     runnerUrl: config.runnerUrl,
     watcherUrl: config.watcherUrl,
+    metaUrl: config.metaUrl,
     diagramCachePath: config.diagramCachePath,
     configPath,
     eventsLog: path.join(rootDir, 'logs', 'webhook-events.jsonl'),

--- a/packages/service/src/config/schema.ts
+++ b/packages/service/src/config/schema.ts
@@ -100,6 +100,12 @@ function getScopeRefs(scopes: unknown): string[] {
 export const jeevesConfigSchema = z
   .object({
     port: z.number().int().positive().default(1934),
+    /**
+     * Network interface to bind the server to.
+     * Default: '0.0.0.0' (all interfaces — required for external access by insiders, share links, etc.)
+     * Set to '127.0.0.1' to restrict to loopback only.
+     */
+    host: z.string().min(1).default('0.0.0.0'),
     chromePath: z.string().min(1),
     auth: authSchema,
     /** Named scope definitions, referenced by insiders/keys/outsiderPolicy */
@@ -150,6 +156,11 @@ export const jeevesConfigSchema = z
      * When set, the search UI appears in the header. Example: 'http://localhost:3458'
      */
     watcherUrl: z.url().optional(),
+    /**
+     * URL of the jeeves-meta API for synthesis engine health checks.
+     * Default: 'http://127.0.0.1:1938'
+     */
+    metaUrl: z.url().default('http://127.0.0.1:1938'),
     /**
      * Global outsider policy â€" constrains which paths are eligible for outsider sharing.
      * Uses the same allow/deny model as insider scopes.

--- a/packages/service/src/config/types.ts
+++ b/packages/service/src/config/types.ts
@@ -50,6 +50,7 @@ export interface ResolvedInsider {
  */
 export interface RuntimeConfig {
   port: number;
+  host: string;
   eventTimeoutMs: number;
   eventLogPurgeMs: number;
   maxZipSizeMb: number;
@@ -64,6 +65,7 @@ export interface RuntimeConfig {
   diagramCachePath?: string;
   runnerUrl?: string;
   watcherUrl?: string;
+  metaUrl?: string;
   outsiderPolicy: NormalizedScopes | null;
   events: JeevesConfig['events'];
   authModes: AuthMode[];

--- a/packages/service/src/routes/api/status.test.ts
+++ b/packages/service/src/routes/api/status.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 // Mock config
 const mockConfig = {
   port: 1934,
+  host: '0.0.0.0',
   chromePath: '/usr/bin/chromium',
   authModes: ['keys'],
   resolvedInsiders: [{ email: 'a@b.com' }, { email: 'c@d.com' }],
@@ -18,6 +19,7 @@ const mockConfig = {
   },
   watcherUrl: null,
   runnerUrl: null,
+  metaUrl: null,
   exportFormats: ['pdf', 'docx', 'zip'],
 };
 

--- a/packages/service/src/routes/api/status.ts
+++ b/packages/service/src/routes/api/status.ts
@@ -44,9 +44,10 @@ export const statusRoutes: FastifyPluginAsync = async (fastify) => {
     async (request) => {
       const config = getConfig();
 
-      const [watcher, runner] = await Promise.all([
+      const [watcher, runner, meta] = await Promise.all([
         config.watcherUrl ? checkService(config.watcherUrl) : null,
         config.runnerUrl ? checkService(config.runnerUrl) : null,
+        config.metaUrl ? checkService(config.metaUrl) : null,
       ]);
 
       return {
@@ -82,6 +83,7 @@ export const statusRoutes: FastifyPluginAsync = async (fastify) => {
         services: {
           watcher,
           runner,
+          meta,
         },
         ...(request.query.events
           ? {

--- a/packages/service/src/routes/config.test.ts
+++ b/packages/service/src/routes/config.test.ts
@@ -11,6 +11,7 @@ import { sanitizeConfig } from './config.js';
 function makeConfig(overrides: Partial<RuntimeConfig> = {}): RuntimeConfig {
   return {
     port: 1934,
+    host: '0.0.0.0',
     eventTimeoutMs: 30_000,
     eventLogPurgeMs: 604_800_000,
     maxZipSizeMb: 100,

--- a/packages/service/src/routes/config.ts
+++ b/packages/service/src/routes/config.ts
@@ -3,7 +3,7 @@
  *
  * Uses the core SDK's `createConfigQueryHandler()` for JSONPath support.
  *
- * @module routes/config
+ * @packageDocumentation
  */
 
 import { createConfigQueryHandler } from '@karmaniverous/jeeves';

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -85,8 +85,10 @@ async function start() {
     // Start queue processor
     startQueueProcessor();
 
-    await fastify.listen({ port: config.port, host: '0.0.0.0' });
-    console.log(`Jeeves server listening on port ${String(config.port)}`);
+    await fastify.listen({ port: config.port, host: config.host });
+    console.log(
+      `Jeeves server listening on ${config.host}:${String(config.port)}`,
+    );
     console.log(`Endpoints:`);
     console.log(`  GET  /browse/* - File browser SPA`);
     console.log(`  GET  /api/raw/*    - Raw file serving`);


### PR DESCRIPTION
Implements #113.

Changes:
- Add `host` config property (default `0.0.0.0`) and bind Fastify to it
- Add `metaUrl` config property (default `http://127.0.0.1:1938`) and include meta in `/api/status` service probing
- Surface host/metaUrl in `jeeves-server config` CLI output