### PR TITLE
Fix runner proxy routes calling wrong endpoints

### DIFF
--- a/packages/service/src/routes/api/runner.ts
+++ b/packages/service/src/routes/api/runner.ts
@@ -45,7 +45,7 @@ export const runnerRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   fastify.get('/api/runner/health', async (_req, reply) => {
-    await proxyToRunner(reply, '/health');
+    await proxyToRunner(reply, '/status');
   });
 
   fastify.get('/api/runner/jobs', async (_req, reply) => {
@@ -102,6 +102,6 @@ export const runnerRoutes: FastifyPluginAsync = async (fastify) => {
   );
 
   fastify.get('/api/runner/stats', async (_req, reply) => {
-    await proxyToRunner(reply, '/stats');
+    await proxyToRunner(reply, '/status');
   });
 };


### PR DESCRIPTION
Fixes #120.

The runner proxy was calling `/stats` and `/health` on the runner API, but the runner exposes `/status` as its single status endpoint (platform convention). Updated both proxy targets to `/status`.