### PR TITLE
Remove /health proxy, rename /stats to /status, align client types

### DIFF
--- a/packages/service/client/src/lib/runner-api.ts
+++ b/packages/service/client/src/lib/runner-api.ts
@@ -54,8 +54,12 @@ interface RawRun {
 }
 
 interface RawStats {
+  status: string;
+  version: string;
+  uptime: number;
   totalJobs: number;
   running: number;
+  failedRegistrations: number;
   okLastHour: number;
   errorsLastHour: number;
 }
@@ -63,8 +67,12 @@ interface RawStats {
 // --- Public types (camelCase) ---
 
 export interface RunnerStats {
+  status: string;
+  version: string;
+  uptime: number;
   totalJobs: number;
   running: number;
+  failedRegistrations: number;
   okLastHour: number;
   errorsLastHour: number;
 }
@@ -124,7 +132,7 @@ function mapRun(raw: RawRun): RunEntry {
 }
 
 export async function getRunnerStats(): Promise<RunnerStats> {
-  const raw = await runnerFetch<RawStats>('/stats');
+  const raw = await runnerFetch<RawStats>('/status');
   return raw;
 }
 

--- a/packages/service/src/routes/api/runner.ts
+++ b/packages/service/src/routes/api/runner.ts
@@ -44,10 +44,6 @@ export const runnerRoutes: FastifyPluginAsync = async (fastify) => {
     }
   });
 
-  fastify.get('/api/runner/health', async (_req, reply) => {
-    await proxyToRunner(reply, '/status');
-  });
-
   fastify.get('/api/runner/jobs', async (_req, reply) => {
     await proxyToRunner(reply, '/jobs');
   });
@@ -101,7 +97,7 @@ export const runnerRoutes: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  fastify.get('/api/runner/stats', async (_req, reply) => {
+  fastify.get('/api/runner/status', async (_req, reply) => {
     await proxyToRunner(reply, '/status');
   });
 };


### PR DESCRIPTION
Continuation of #120 (merged PR #121 had the proxy target fix only).

Additional changes:
- Removed `GET /api/runner/health` proxy entirely
- Renamed `GET /api/runner/stats` to `GET /api/runner/status`
- Client `RunnerStats` type now includes all fields from runner's `GET /status` response (`status`, `version`, `uptime`, `failedRegistrations`)
- Client calls `/status` instead of `/stats`