### PR TITLE
Fix config validate test assertion

### DIFF
--- a/packages/service/src/cli/commands/config.test.ts
+++ b/packages/service/src/cli/commands/config.test.ts
@@ -53,7 +53,7 @@ describe('jeeves-server config validate', () => {
   it('validates a valid config and prints success', async () => {
     const configPath = writeConfig(tmpDir, VALID_CONFIG);
     const { stdout } = await runCli(['config', 'validate', '-c', configPath]);
-    expect(stdout).toContain('Config is valid');
+    expect(stdout).toContain('Configuration valid');
   });
 
   it('exits with error for invalid config', async () => {


### PR DESCRIPTION
The core SDK config validate command now outputs Configuration valid instead of Config is valid. Updates the test assertion to match.