### PR TITLE
feat: v3.7.0 / v0.8.0 — shareable URLs, insider checkbox toggles, events route fix

### DIFF
--- a/packages/openclaw/CHANGELOG.md
+++ b/packages/openclaw/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [v0.8.0](https://github.com/karmaniverous/jeeves-server/compare/v0.7.5...v0.8.0)
+
+> 11 April 2026
+
+- feat: add `publicUrl` plugin config for automatic URL rewriting in tool responses [`#145`](https://github.com/karmaniverous/jeeves-server/pull/145)
+- feat: add `rewriteUrl` and `rewriteUrlsInData` helpers for origin-based URL rewriting [`#145`](https://github.com/karmaniverous/jeeves-server/pull/145)
+- feat: update TOOLS.md guidance to describe automatic URL rewriting and checkbox toggling [`#152`](https://github.com/karmaniverous/jeeves-server/pull/152)
+- feat: add `server_event_status` tool querying `/api/events` endpoint [`#156`](https://github.com/karmaniverous/jeeves-server/pull/156)
+- docs: sync all documentation surfaces with v3.7.0 implementation
+
 #### [v0.7.5](https://github.com/karmaniverous/jeeves-server/compare/v2.9.3...v0.7.5)
 
 - fix: consume core importMetaUrl for plugin install (#150, #147) [`#151`](https://github.com/karmaniverous/jeeves-server/pull/151)

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -38,7 +38,8 @@ Add an unscoped `_plugin` key to your Jeeves Server config:
         "config": {
           "apiUrl": "http://127.0.0.1:1934",
           "pluginKey": "<same-seed-as-server-_plugin>",
-          "configRoot": "j:/config"
+          "configRoot": "j:/config",
+          "publicUrl": "https://jeeves.example.com"
         }
       }
     }
@@ -51,6 +52,7 @@ Add an unscoped `_plugin` key to your Jeeves Server config:
 | `apiUrl` | `http://127.0.0.1:1934` | Server API base URL |
 | `pluginKey` | — | Server `_plugin` key seed |
 | `configRoot` | `j:/config` | Platform config root (core derives component config dirs) |
+| `publicUrl` | — | Public base URL for shareable links. When set, URLs returned by tools are rewritten to this host. |
 
 ## Docs
 

--- a/packages/openclaw/guides/openclaw-integration.md
+++ b/packages/openclaw/guides/openclaw-integration.md
@@ -49,7 +49,8 @@ In `openclaw.json`, configure the plugin entry:
         "config": {
           "apiUrl": "http://127.0.0.1:1934",
           "pluginKey": "same-hex-seed-as-server-_plugin-key",
-          "configRoot": "j:/config"
+          "configRoot": "j:/config",
+          "publicUrl": "https://jeeves.example.com"
         }
       }
     }
@@ -62,6 +63,7 @@ In `openclaw.json`, configure the plugin entry:
 | `apiUrl` | No | `http://127.0.0.1:1934` | jeeves-server API base URL |
 | `pluginKey` | No | — | Server `_plugin` key seed (for authenticated API calls) |
 | `configRoot` | No | `j:/config` | Platform config root directory. Core derives component config dirs from this path. |
+| `publicUrl` | No | — | Public base URL (e.g. `https://jeeves.example.com`). When set, all URLs returned by tools are rewritten to use this host instead of `apiUrl`. |
 
 ## Tools
 

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "jeeves-server-openclaw",
   "name": "Jeeves Server",
   "description": "File browsing, document sharing, export, and event gateway tools for jeeves-server.",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "skills": [
     "dist/skills/jeeves-server"
   ],

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -23,6 +23,10 @@
         "type": "string",
         "description": "Platform config root directory (e.g. j:/config). Core derives component config dirs from this path.",
         "default": "j:/config"
+      },
+      "publicUrl": {
+        "type": "string",
+        "description": "Public base URL for shareable links (e.g. https://jeeves.johngalt.id). When set, all URLs returned to tool callers are rewritten to use this host. When absent, URLs use the apiUrl (development behavior)."
       }
     }
   },
@@ -38,6 +42,10 @@
     "configRoot": {
       "label": "Config Root",
       "placeholder": "j:/config"
+    },
+    "publicUrl": {
+      "label": "Public URL",
+      "placeholder": "https://jeeves.johngalt.id"
     }
   }
 }

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karmaniverous/jeeves-server-openclaw",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/openclaw/skills/jeeves-server/SKILL.md
+++ b/packages/openclaw/skills/jeeves-server/SKILL.md
@@ -24,6 +24,14 @@ To convert a Windows file path to a browse path:
 - `J:\domains\projects\readme.md` → `j/domains/projects/readme.md`
 - Strip the colon, lowercase the drive letter, use forward slashes
 
+## Public URL Rewriting
+
+When the `publicUrl` plugin config is set (e.g. `https://jeeves.example.com`), all URLs returned by server tools are automatically rewritten to use the public domain instead of the internal `apiUrl`. No manual URL rewriting is needed.
+
+## Checkbox Toggling
+
+Insiders can toggle GFM task-list checkboxes in rendered Markdown pages via the web UI. The server exposes `POST /api/file/*/toggle-checkbox` with stale-write protection (mtime-based conflict detection). This is a web-UI feature — no agent tool is required.
+
 ## Browse Features
 
 - **Directory item counts:** Subdirectory rows display a nonrecursive item count in the Size column.

--- a/packages/openclaw/skills/jeeves-server/SKILL.md
+++ b/packages/openclaw/skills/jeeves-server/SKILL.md
@@ -30,7 +30,7 @@ When the `publicUrl` plugin config is set (e.g. `https://jeeves.example.com`), a
 
 ## Checkbox Toggling
 
-Insiders can toggle GFM task-list checkboxes in rendered Markdown pages via the web UI. The server exposes `POST /api/file/*/toggle-checkbox` with stale-write protection (mtime-based conflict detection). This is a web-UI feature — no agent tool is required.
+Insiders can toggle GFM task-list checkboxes in rendered Markdown pages via the web UI. The server exposes `POST /api/toggle-checkbox/*` with stale-write protection (mtime-based conflict detection). This is a web-UI feature — no agent tool is required.
 
 ## Browse Features
 

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -18,6 +18,7 @@ import {
   jeevesComponentDescriptorSchema,
   loadWorkspaceConfig,
   type PluginApi,
+  resolveOptionalPluginSetting,
   resolvePluginSetting,
   resolveWorkspacePath,
   SERVER_PORT,
@@ -49,6 +50,16 @@ function getServiceUrl(api: PluginApi): string {
     'apiUrl',
     'JEEVES_SERVER_URL',
     'http://127.0.0.1:1934',
+  );
+}
+
+/** Resolve the optional public URL for shareable links. */
+function getPublicUrl(api: PluginApi): string | undefined {
+  return resolveOptionalPluginSetting(
+    api,
+    PLUGIN_ID,
+    'publicUrl',
+    'JEEVES_SERVER_PUBLIC_URL',
   );
 }
 
@@ -153,7 +164,8 @@ export default function register(api: PluginApi): void {
     api.registerTool(tool, { optional: true });
   }
 
-  registerServerTools(api, baseUrl);
+  const publicUrl = getPublicUrl(api);
+  registerServerTools(api, baseUrl, publicUrl);
 
   // Resolve gatewayUrl for cleanup escalation
   const wsConfig = loadWorkspaceConfig(workspacePath);

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -78,6 +78,17 @@ describe('generateServerMenu', () => {
     expect(menu).toContain('3 insider(s)');
   });
 
+  it('mentions automatic URL rewriting in sharing guidance', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => ({ version: '3.0.0', health: {} }),
+    } as unknown as Response);
+    const menu = await generateServerMenu('http://localhost:1934');
+    expect(menu).toContain('automatically rewritten');
+    expect(menu).toContain('publicUrl');
+    expect(menu).not.toContain('always rewrite');
+  });
+
   it('does not render connected services (plugin isolation #128)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -114,6 +114,13 @@ export async function generateServerMenu(apiUrl: string): Promise<string> {
     lines.push('');
   }
 
+  // Checkbox toggling
+  lines.push('### Editing');
+  lines.push(
+    'Insiders can toggle GFM task-list checkboxes in rendered Markdown pages. The server exposes `POST /api/file/*/toggle-checkbox` with stale-write protection (mtime). This is used by the web UI — no agent tool is needed.',
+  );
+  lines.push('');
+
   // Sharing guidance
   lines.push('### Sharing');
   lines.push(

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -117,7 +117,7 @@ export async function generateServerMenu(apiUrl: string): Promise<string> {
   // Checkbox toggling
   lines.push('### Editing');
   lines.push(
-    'Insiders can toggle GFM task-list checkboxes in rendered Markdown pages. The server exposes `POST /api/file/*/toggle-checkbox` with stale-write protection (mtime). This is used by the web UI — no agent tool is needed.',
+    'Insiders can toggle GFM task-list checkboxes in rendered Markdown pages. The server exposes `POST /api/toggle-checkbox/*` with stale-write protection (mtime). This is used by the web UI — no agent tool is needed.',
   );
   lines.push('');
 

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -122,6 +122,9 @@ export async function generateServerMenu(apiUrl: string): Promise<string> {
   lines.push(
     'Use `server_link_info` to check available export formats for a path before exporting.',
   );
+  lines.push(
+    'URLs returned by server tools are automatically rewritten to use the public domain when `publicUrl` is configured. No manual URL rewriting is needed.',
+  );
 
   return lines.join('\n');
 }

--- a/packages/openclaw/src/serverTools.test.ts
+++ b/packages/openclaw/src/serverTools.test.ts
@@ -33,6 +33,23 @@ describe('rewriteUrl', () => {
       'https://jeeves.johngalt.id/',
     );
   });
+
+  it('handles HTTPS base URL with port', () => {
+    const httpsBase = 'https://localhost:8443';
+    const pub = 'https://public.example.com';
+    expect(rewriteUrl(`${httpsBase}/browse/file.md`, httpsBase, pub)).toBe(
+      'https://public.example.com/browse/file.md',
+    );
+  });
+
+  it('does not rewrite URL when origins differ only by port', () => {
+    const base = 'http://127.0.0.1:1934';
+    const pub = 'https://jeeves.johngalt.id';
+    // URL on port 3000 should NOT be rewritten
+    expect(rewriteUrl('http://127.0.0.1:3000/other', base, pub)).toBe(
+      'http://127.0.0.1:3000/other',
+    );
+  });
 });
 
 describe('rewriteUrlsInData', () => {

--- a/packages/openclaw/src/serverTools.test.ts
+++ b/packages/openclaw/src/serverTools.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import { rewriteUrl, rewriteUrlsInData } from './serverTools.js';
+
+describe('rewriteUrl', () => {
+  const baseUrl = 'http://127.0.0.1:1934';
+  const publicUrl = 'https://jeeves.johngalt.id';
+
+  it('rewrites a URL that starts with the baseUrl origin', () => {
+    expect(
+      rewriteUrl(`${baseUrl}/browse/j/docs/readme.md`, baseUrl, publicUrl),
+    ).toBe('https://jeeves.johngalt.id/browse/j/docs/readme.md');
+  });
+
+  it('preserves query parameters', () => {
+    expect(
+      rewriteUrl(
+        `${baseUrl}/api/export/file.md?format=pdf`,
+        baseUrl,
+        publicUrl,
+      ),
+    ).toBe('https://jeeves.johngalt.id/api/export/file.md?format=pdf');
+  });
+
+  it('leaves non-matching URLs unchanged', () => {
+    expect(
+      rewriteUrl('https://other.example.com/path', baseUrl, publicUrl),
+    ).toBe('https://other.example.com/path');
+  });
+
+  it('handles trailing slashes correctly', () => {
+    expect(rewriteUrl(`${baseUrl}/`, baseUrl, publicUrl)).toBe(
+      'https://jeeves.johngalt.id/',
+    );
+  });
+});
+
+describe('rewriteUrlsInData', () => {
+  const baseUrl = 'http://127.0.0.1:1934';
+  const publicUrl = 'https://jeeves.johngalt.id';
+
+  it('returns data unchanged when publicUrl is undefined', () => {
+    const data = { url: `${baseUrl}/browse/file.md` };
+    expect(rewriteUrlsInData(data, baseUrl, undefined)).toEqual(data);
+  });
+
+  it('rewrites string values in a flat object', () => {
+    const data = {
+      pageUrl: `${baseUrl}/browse/j/docs/readme.md?key=abc`,
+      rawUrl: `${baseUrl}/raw/j/docs/readme.md?key=abc`,
+      path: '/j/docs/readme.md',
+    };
+
+    const result = rewriteUrlsInData(data, baseUrl, publicUrl) as typeof data;
+    expect(result.pageUrl).toBe(
+      'https://jeeves.johngalt.id/browse/j/docs/readme.md?key=abc',
+    );
+    expect(result.rawUrl).toBe(
+      'https://jeeves.johngalt.id/raw/j/docs/readme.md?key=abc',
+    );
+    expect(result.path).toBe('/j/docs/readme.md');
+  });
+
+  it('rewrites URLs in nested objects', () => {
+    const data = {
+      links: {
+        page: `${baseUrl}/browse/file.md`,
+        exports: {
+          pdf: `${baseUrl}/api/export/file.md?format=pdf`,
+        },
+      },
+    };
+
+    const result = rewriteUrlsInData(data, baseUrl, publicUrl) as {
+      links: { page: string; exports: { pdf: string } };
+    };
+    expect(result.links.page).toBe('https://jeeves.johngalt.id/browse/file.md');
+    expect(result.links.exports.pdf).toBe(
+      'https://jeeves.johngalt.id/api/export/file.md?format=pdf',
+    );
+  });
+
+  it('rewrites URLs in arrays', () => {
+    const data = [
+      `${baseUrl}/browse/a.md`,
+      `${baseUrl}/browse/b.md`,
+      'not-a-url',
+    ];
+
+    const result = rewriteUrlsInData(data, baseUrl, publicUrl) as string[];
+    expect(result[0]).toBe('https://jeeves.johngalt.id/browse/a.md');
+    expect(result[1]).toBe('https://jeeves.johngalt.id/browse/b.md');
+    expect(result[2]).toBe('not-a-url');
+  });
+
+  it('handles null and primitive values', () => {
+    expect(rewriteUrlsInData(null, baseUrl, publicUrl)).toBeNull();
+    expect(rewriteUrlsInData(42, baseUrl, publicUrl)).toBe(42);
+    expect(rewriteUrlsInData(true, baseUrl, publicUrl)).toBe(true);
+  });
+
+  it('rewrites the server_share response shape', () => {
+    const shareResponse = {
+      path: '/j/docs/readme.md',
+      url: `${baseUrl}/browse/j/docs/readme.md?key=abc123`,
+      pageUrl: `${baseUrl}/browse/j/docs/readme.md?key=abc123`,
+      rawUrl: `${baseUrl}/raw/j/docs/readme.md?key=abc123`,
+      exp: null,
+      depth: 0,
+      dirs: false,
+    };
+
+    const result = rewriteUrlsInData(
+      shareResponse,
+      baseUrl,
+      publicUrl,
+    ) as typeof shareResponse;
+    expect(result.url).toBe(
+      'https://jeeves.johngalt.id/browse/j/docs/readme.md?key=abc123',
+    );
+    expect(result.pageUrl).toBe(
+      'https://jeeves.johngalt.id/browse/j/docs/readme.md?key=abc123',
+    );
+    expect(result.rawUrl).toBe(
+      'https://jeeves.johngalt.id/raw/j/docs/readme.md?key=abc123',
+    );
+    expect(result.path).toBe('/j/docs/readme.md');
+  });
+});

--- a/packages/openclaw/src/serverTools.test.ts
+++ b/packages/openclaw/src/serverTools.test.ts
@@ -50,6 +50,39 @@ describe('rewriteUrl', () => {
       'http://127.0.0.1:3000/other',
     );
   });
+
+  it('does not false-positive on port prefix match (e.g. :1934 vs :19345)', () => {
+    const base = 'http://localhost:1934';
+    const pub = 'https://public.example.com';
+    // Port 19345 starts with "1934" but is a different origin
+    expect(rewriteUrl('http://localhost:19345/path', base, pub)).toBe(
+      'http://localhost:19345/path',
+    );
+  });
+
+  it('rewrites exact origin with no trailing path', () => {
+    const base = 'http://localhost:1934';
+    const pub = 'https://public.example.com';
+    expect(rewriteUrl('http://localhost:1934', base, pub)).toBe(
+      'https://public.example.com',
+    );
+  });
+
+  it('rewrites origin followed by query string', () => {
+    const base = 'http://localhost:1934';
+    const pub = 'https://public.example.com';
+    expect(rewriteUrl('http://localhost:1934?foo=bar', base, pub)).toBe(
+      'https://public.example.com?foo=bar',
+    );
+  });
+
+  it('rewrites origin followed by fragment', () => {
+    const base = 'http://localhost:1934';
+    const pub = 'https://public.example.com';
+    expect(rewriteUrl('http://localhost:1934#section', base, pub)).toBe(
+      'https://public.example.com#section',
+    );
+  });
 });
 
 describe('rewriteUrlsInData', () => {
@@ -114,6 +147,12 @@ describe('rewriteUrlsInData', () => {
     expect(rewriteUrlsInData(null, baseUrl, publicUrl)).toBeNull();
     expect(rewriteUrlsInData(42, baseUrl, publicUrl)).toBe(42);
     expect(rewriteUrlsInData(true, baseUrl, publicUrl)).toBe(true);
+  });
+
+  it('does not false-positive on port prefix match in data', () => {
+    const data = { url: 'http://127.0.0.1:19345/path' };
+    const result = rewriteUrlsInData(data, baseUrl, publicUrl) as typeof data;
+    expect(result.url).toBe('http://127.0.0.1:19345/path');
   });
 
   it('rewrites the server_share response shape', () => {

--- a/packages/openclaw/src/serverTools.ts
+++ b/packages/openclaw/src/serverTools.ts
@@ -29,6 +29,13 @@ function toAbsoluteUrl(baseUrl: string, url: string): string {
   return new URL(url, baseUrl).toString();
 }
 
+/** Check that the character after a prefix match is a valid URL boundary. */
+function isOriginBoundary(url: string, originLength: number): boolean {
+  if (url.length <= originLength) return true;
+  const next = url[originLength];
+  return next === '/' || next === '?' || next === '#';
+}
+
 /**
  * Rewrite a single URL string: replace the baseUrl origin with publicUrl origin.
  * Only rewrites URLs that start with the baseUrl origin.
@@ -40,7 +47,10 @@ export function rewriteUrl(
 ): string {
   const base = new URL(baseUrl);
   const pub = new URL(publicUrl);
-  if (url.startsWith(base.origin)) {
+  if (
+    url.startsWith(base.origin) &&
+    isOriginBoundary(url, base.origin.length)
+  ) {
     return pub.origin + url.slice(base.origin.length);
   }
   return url;
@@ -62,7 +72,10 @@ export function rewriteUrlsInData(
 
   function walk(value: unknown): unknown {
     if (typeof value === 'string') {
-      if (value.startsWith(baseOrigin)) {
+      if (
+        value.startsWith(baseOrigin) &&
+        isOriginBoundary(value, baseOrigin.length)
+      ) {
         return pubOrigin + value.slice(baseOrigin.length);
       }
       return value;

--- a/packages/openclaw/src/serverTools.ts
+++ b/packages/openclaw/src/serverTools.ts
@@ -26,6 +26,60 @@ function toAbsoluteUrl(baseUrl: string, url: string): string {
   return new URL(url, baseUrl).toString();
 }
 
+/**
+ * Rewrite a single URL string: replace the baseUrl origin with publicUrl origin.
+ * Only rewrites URLs that start with the baseUrl origin.
+ */
+export function rewriteUrl(
+  url: string,
+  baseUrl: string,
+  publicUrl: string,
+): string {
+  const base = new URL(baseUrl);
+  const pub = new URL(publicUrl);
+  if (url.startsWith(base.origin)) {
+    return pub.origin + url.slice(base.origin.length);
+  }
+  return url;
+}
+
+/**
+ * Deep-walk a JSON-serializable value and rewrite any string that starts
+ * with the baseUrl origin to use the publicUrl origin instead.
+ */
+export function rewriteUrlsInData(
+  data: unknown,
+  baseUrl: string,
+  publicUrl: string | undefined,
+): unknown {
+  if (!publicUrl) return data;
+
+  const pub = publicUrl;
+  const baseOrigin = new URL(baseUrl).origin;
+
+  function walk(value: unknown): unknown {
+    if (typeof value === 'string') {
+      if (value.startsWith(baseOrigin)) {
+        return rewriteUrl(value, baseUrl, pub);
+      }
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map(walk);
+    }
+    if (value !== null && typeof value === 'object') {
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        result[k] = walk(v);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  return walk(data);
+}
+
 /** Config for a server API tool. */
 interface ApiToolConfig {
   name: string;
@@ -48,6 +102,7 @@ function registerApiTool(
   api: PluginApi,
   baseUrl: string,
   keySeed: string | undefined,
+  publicUrl: string | undefined,
   config: ApiToolConfig,
 ): void {
   api.registerTool(
@@ -73,9 +128,10 @@ function registerApiTool(
             url,
             Object.keys(init).length > 0 ? init : undefined,
           );
-          const data = config.transformResponse
+          const transformed = config.transformResponse
             ? config.transformResponse(rawData, baseUrl, params)
             : rawData;
+          const data = rewriteUrlsInData(transformed, baseUrl, publicUrl);
           return ok(data);
         } catch (error) {
           return connectionFail(error, baseUrl, PLUGIN_ID);
@@ -87,7 +143,11 @@ function registerApiTool(
 }
 
 /** Register all domain-specific server_* tools with the OpenClaw plugin API. */
-export function registerServerTools(api: PluginApi, baseUrl: string): void {
+export function registerServerTools(
+  api: PluginApi,
+  baseUrl: string,
+  publicUrl?: string,
+): void {
   const keySeed = getPluginKey(api);
 
   const tools: ApiToolConfig[] = [
@@ -217,7 +277,7 @@ export function registerServerTools(api: PluginApi, baseUrl: string): void {
   ];
 
   for (const tool of tools) {
-    registerApiTool(api, baseUrl, keySeed, tool);
+    registerApiTool(api, baseUrl, keySeed, publicUrl, tool);
   }
 
   api.registerTool(
@@ -256,12 +316,13 @@ export function registerServerTools(api: PluginApi, baseUrl: string): void {
             : [];
           const recent = Array.isArray(recentEvents) ? recentEvents : [];
 
-          return ok({
+          const result = {
             activeSchemas,
             schemaCount: activeSchemas.length,
             recentEvents: recent,
             recentCount: recent.length,
-          });
+          };
+          return ok(rewriteUrlsInData(result, baseUrl, publicUrl));
         } catch (error) {
           return connectionFail(error, baseUrl, PLUGIN_ID);
         }

--- a/packages/openclaw/src/serverTools.ts
+++ b/packages/openclaw/src/serverTools.ts
@@ -16,6 +16,9 @@ import {
 import { PLUGIN_ID } from './constants.js';
 import { getPluginKey, withAuth } from './helpers.js';
 
+/** Milliseconds in one day. */
+const MS_PER_DAY = 86_400_000;
+
 /** Normalize a browse path param: strip leading slash. */
 function normalizePath(params: Record<string, unknown>): string {
   return String(params.path).replace(/^\//, '');
@@ -54,13 +57,13 @@ export function rewriteUrlsInData(
 ): unknown {
   if (!publicUrl) return data;
 
-  const pub = publicUrl;
   const baseOrigin = new URL(baseUrl).origin;
+  const pubOrigin = new URL(publicUrl).origin;
 
   function walk(value: unknown): unknown {
     if (typeof value === 'string') {
       if (value.startsWith(baseOrigin)) {
-        return rewriteUrl(value, baseUrl, pub);
+        return pubOrigin + value.slice(baseOrigin.length);
       }
       return value;
     }
@@ -220,7 +223,7 @@ export function registerServerTools(
         const p = normalizePath(params);
         const body: Record<string, unknown> = { path: '/' + p };
         if (params.expiryDays !== undefined) {
-          const ms = Date.now() + (params.expiryDays as number) * 86400000;
+          const ms = Date.now() + (params.expiryDays as number) * MS_PER_DAY;
           body.expiry = String(ms);
         }
         if (params.depth !== undefined) body.depth = params.depth;

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. Dates are d
 > 11 April 2026
 
 - feat: add checkbox indexing to markdown pipeline with sequential `data-checkbox-index` attributes [`#154`](https://github.com/karmaniverous/jeeves-server/pull/154)
-- feat: add `POST /api/file/*/toggle-checkbox` endpoint with insider-only access and mtime stale-write protection [`#154`](https://github.com/karmaniverous/jeeves-server/pull/154)
+- feat: add `POST /api/toggle-checkbox/*` endpoint with insider-only access and mtime stale-write protection [`#154`](https://github.com/karmaniverous/jeeves-server/pull/154)
 - feat: wire MarkdownView checkbox toggling with optimistic UI and conflict refetch [`#154`](https://github.com/karmaniverous/jeeves-server/pull/154)
 - fix: correct event log route path from `/events` to `/api/events` [`#156`](https://github.com/karmaniverous/jeeves-server/pull/156)
 

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [3.7.0](https://github.com/karmaniverous/jeeves-server/compare/service/3.6.5...3.7.0)
+
+> 11 April 2026
+
+- feat: add checkbox indexing to markdown pipeline with sequential `data-checkbox-index` attributes [`#154`](https://github.com/karmaniverous/jeeves-server/pull/154)
+- feat: add `POST /api/file/*/toggle-checkbox` endpoint with insider-only access and mtime stale-write protection [`#154`](https://github.com/karmaniverous/jeeves-server/pull/154)
+- feat: wire MarkdownView checkbox toggling with optimistic UI and conflict refetch [`#154`](https://github.com/karmaniverous/jeeves-server/pull/154)
+- fix: correct event log route path from `/events` to `/api/events` [`#156`](https://github.com/karmaniverous/jeeves-server/pull/156)
+
 #### [3.6.5](https://github.com/karmaniverous/jeeves-server/compare/service/3.6.4...3.6.5)
 
 - npm audit fix [`9390169`](https://github.com/karmaniverous/jeeves-server/commit/9390169fd9763e5e81a96ff42b9d25eb0f32c38a)

--- a/packages/service/client/src/components/FileContentView.tsx
+++ b/packages/service/client/src/components/FileContentView.tsx
@@ -30,6 +30,7 @@ interface FileContentViewProps {
   mobileTocOpen: boolean;
   setMobileTocOpen: (open: boolean) => void;
   onSave: (content: string) => Promise<void>;
+  onRefetch: () => void;
   loading: boolean;
 }
 
@@ -39,6 +40,7 @@ export function FileContentView({
   proseWidth, topBarHeight, mainRef,
   mobileTocOpen, setMobileTocOpen,
   onSave,
+  onRefetch,
 }: FileContentViewProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   useScrollAnchor(mainRef, contentRef);
@@ -107,6 +109,8 @@ export function FileContentView({
       {fileRendered?.type === 'markdown' && fileRendered.html && activeTab === 'rendered' && (
         <MarkdownView
           fileRendered={fileRendered}
+          reqPath={reqPath}
+          onRefetch={onRefetch}
           proseWidth={proseWidth}
           topBarHeight={topBarHeight}
           mainRef={mainRef}

--- a/packages/service/client/src/components/MarkdownView.tsx
+++ b/packages/service/client/src/components/MarkdownView.tsx
@@ -1,7 +1,7 @@
 /**
  * Markdown rendered view with collapsible TOC sidebar.
  */
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { initEmbeddedDiagramPanzoom } from '@/components/EmbeddedDiagramPanzoom';
 import { initLazyDiagrams } from '@/components/LazyDiagram';
@@ -9,6 +9,7 @@ import { initInlineSvgPanzoom } from '@/components/InlineSvgPanzoom';
 import { TocSection } from '@/components/TocSection';
 import { buildTocTree, findAncestorSlugs } from '@/components/tocUtils';
 import type { FileContent } from '@/lib/api';
+import { toggleCheckbox } from '@/lib/api';
 import { initCodeBlockCm6 } from '@/lib/codeBlockCm6';
 import { injectCopyButtons } from '@/lib/codeBlockCopy';
 import { useTheme } from '@/lib/theme';
@@ -16,6 +17,8 @@ import { scrollToIdInContainer } from './scrollUtils';
 
 interface MarkdownViewProps {
   fileRendered: FileContent;
+  reqPath: string;
+  onRefetch: () => void;
   proseWidth: 'narrow' | 'medium' | 'wide';
   topBarHeight: number;
   mainRef: React.RefObject<HTMLElement | null>;
@@ -24,12 +27,24 @@ interface MarkdownViewProps {
 }
 
 export function MarkdownView({
-  fileRendered, proseWidth, topBarHeight, mainRef,
+  fileRendered, reqPath, onRefetch, proseWidth, topBarHeight, mainRef,
   mobileTocOpen, setMobileTocOpen,
 }: MarkdownViewProps) {
   const [theme] = useTheme();
   const plainCode = new URLSearchParams(window.location.search).has('plain_code');
   const hasHeadings = fileRendered.headings && fileRendered.headings.length > 2;
+  const articleRef = useRef<HTMLElement | null>(null);
+  const [toggling, setToggling] = useState(false);
+  const mtimeRef = useRef<number>(fileRendered.mtime ?? 0);
+
+  // Update mtime when fileRendered changes (e.g. after refetch)
+  useEffect(() => {
+    if (fileRendered.mtime !== undefined) {
+      mtimeRef.current = fileRendered.mtime;
+    }
+  }, [fileRendered.mtime]);
+
+  const isInsider = fileRendered.isInsider;
 
   // Build TOC tree and collapse state
   const tocTree = useMemo(
@@ -71,6 +86,58 @@ export function MarkdownView({
     },
     [scrollToHeading, setMobileTocOpen],
   );
+
+  // Setup checkbox interactivity after render
+  useEffect(() => {
+    const el = articleRef.current;
+    if (!el) return;
+
+    const checkboxes = el.querySelectorAll<HTMLInputElement>('input[type="checkbox"][data-checkbox-index]');
+    checkboxes.forEach((cb) => {
+      if (isInsider && !toggling) {
+        cb.disabled = false;
+        cb.style.cursor = 'pointer';
+      } else {
+        cb.disabled = true;
+        cb.style.cursor = '';
+      }
+    });
+  }, [fileRendered.html, isInsider, toggling]);
+
+  const handleCheckboxClick = useCallback(async (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName !== 'INPUT' || (target as HTMLInputElement).type !== 'checkbox') return;
+
+    const input = target as HTMLInputElement;
+    const indexAttr = input.getAttribute('data-checkbox-index');
+    if (indexAttr === null) return;
+    if (!isInsider) return;
+
+    e.preventDefault();
+    const index = parseInt(indexAttr, 10);
+    const checked = !input.checked; // Toggle the current state
+
+    setToggling(true);
+    // Visually toggle immediately for responsiveness
+    input.checked = checked;
+    input.disabled = true;
+
+    try {
+      const result = await toggleCheckbox(reqPath, index, checked, mtimeRef.current);
+
+      if (result.conflict) {
+        // Stale write - refetch
+        onRefetch();
+      } else if (result.ok) {
+        mtimeRef.current = result.mtime;
+      }
+    } catch {
+      // Revert the visual toggle on error
+      input.checked = !checked;
+    } finally {
+      setToggling(false);
+    }
+  }, [isInsider, reqPath, onRefetch]);
 
   return (
     <>
@@ -121,7 +188,16 @@ export function MarkdownView({
 
         {/* Markdown article */}
         <article
-          ref={(el) => { if (el) { if (!plainCode) initCodeBlockCm6(el, theme); injectCopyButtons(el); initInlineSvgPanzoom(el); initEmbeddedDiagramPanzoom(el); initLazyDiagrams(el); } }}
+          ref={(el) => {
+            articleRef.current = el;
+            if (el) {
+              if (!plainCode) initCodeBlockCm6(el, theme);
+              injectCopyButtons(el);
+              initInlineSvgPanzoom(el);
+              initEmbeddedDiagramPanzoom(el);
+              initLazyDiagrams(el);
+            }
+          }}
           className={`prose bg-background p-6 rounded-lg border border-border min-w-0 flex-1 ${
             proseWidth === 'narrow' ? 'max-w-prose' : proseWidth === 'medium' ? 'max-w-5xl' : 'max-w-none'
           }`}
@@ -142,6 +218,14 @@ export function MarkdownView({
           dangerouslySetInnerHTML={{ __html: fileRendered.html! }}
           onClick={(e) => {
             const target = e.target as HTMLElement;
+
+            // Handle checkbox clicks
+            if (target.tagName === 'INPUT' && (target as HTMLInputElement).type === 'checkbox') {
+              void handleCheckboxClick(e);
+              return;
+            }
+
+            // Handle anchor clicks
             const anchor = target.closest('a');
             const href = anchor?.getAttribute('href');
             if (href?.startsWith('#')) {

--- a/packages/service/client/src/hooks/useFileBrowser.ts
+++ b/packages/service/client/src/hooks/useFileBrowser.ts
@@ -41,7 +41,7 @@ export function useFileBrowser() {
     drives, directory, fileRaw, fileRendered, file,
     loading, error, editing, setEditing,
     viewTab, setViewTab: setViewTabInternal,
-    handleSave,
+    handleSave, refetchFile,
   } = useFileData(reqPath, searchParams);
 
   // Sync tab to URL
@@ -97,6 +97,6 @@ export function useFileBrowser() {
     rotateKeyDialogOpen, setRotateKeyDialogOpen,
     handleRotateKey, confirmRotateKey,
     topBarRef, mainRef, topBarHeight,
-    handleSave,
+    handleSave, refetchFile,
   };
 }

--- a/packages/service/client/src/hooks/useFileData.ts
+++ b/packages/service/client/src/hooks/useFileData.ts
@@ -70,11 +70,17 @@ export function useFileData(reqPath: string, searchParams: URLSearchParams) {
     setEditing(false);
   };
 
+  const refetchFile = useCallback(() => {
+    if (!reqPath) return;
+    getFileRaw(reqPath).then(setFileRaw).catch(() => {});
+    getFile(reqPath).then(setFileRendered).catch(() => {});
+  }, [reqPath]);
+
   return {
     drives, directory, fileRaw, fileRendered, file,
     loading, error,
     editing, setEditing,
     viewTab, setViewTab: setViewTabInternal,
-    handleSave,
+    handleSave, refetchFile,
   };
 }

--- a/packages/service/client/src/lib/api.ts
+++ b/packages/service/client/src/lib/api.ts
@@ -250,7 +250,7 @@ export async function toggleCheckbox(
   checked: boolean,
   mtime: number,
 ): Promise<ToggleCheckboxResult> {
-  const url = withKey(`${API_BASE}/file/${encodeBrowsePath(filePath)}/toggle-checkbox`);
+  const url = withKey(`${API_BASE}/toggle-checkbox/${encodeBrowsePath(filePath)}`);
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/packages/service/client/src/lib/api.ts
+++ b/packages/service/client/src/lib/api.ts
@@ -69,6 +69,7 @@ export interface FileContent {
   fileName: string;
   breadcrumbs: BreadcrumbItem[];
   isInsider: boolean;
+  mtime?: number;
 }
 
 export interface ShareResponse {
@@ -235,6 +236,39 @@ export interface FacetsResponse {
 
 export async function fetchFacets(): Promise<FacetsResponse> {
   return fetchJson<FacetsResponse>(`${API_BASE}/search/facets`);
+}
+
+export interface ToggleCheckboxResult {
+  ok: boolean;
+  mtime: number;
+  conflict?: boolean;
+}
+
+export async function toggleCheckbox(
+  filePath: string,
+  index: number,
+  checked: boolean,
+  mtime: number,
+): Promise<ToggleCheckboxResult> {
+  const url = withKey(`${API_BASE}/file/${encodeBrowsePath(filePath)}/toggle-checkbox`);
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ index, checked, mtime }),
+    credentials: 'same-origin',
+  });
+
+  if (res.status === 409) {
+    const body = await res.json() as { conflict: boolean; mtime: number };
+    return { ok: false, conflict: true, mtime: body.mtime };
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Toggle failed: ${body}`);
+  }
+
+  return res.json() as Promise<ToggleCheckboxResult>;
 }
 
 export async function clearCache(path: string): Promise<{ cleared: { exports: number; diagrams: number } }> {

--- a/packages/service/client/src/pages/FileBrowser.tsx
+++ b/packages/service/client/src/pages/FileBrowser.tsx
@@ -24,7 +24,7 @@ export function FileBrowser() {
     rotateKeyDialogOpen, setRotateKeyDialogOpen,
     handleRotateKey, confirmRotateKey,
     topBarRef, mainRef, topBarHeight,
-    handleSave,
+    handleSave, refetchFile,
   } = useFileBrowser();
 
   const showFileView = file || (loading && !!reqPath);
@@ -117,6 +117,7 @@ export function FileBrowser() {
             mobileTocOpen={mobileTocOpen}
             setMobileTocOpen={setMobileTocOpen}
             onSave={handleSave}
+            onRefetch={refetchFile}
             loading={loading}
           />
         )}

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karmaniverous/jeeves-server",
-  "version": "3.6.5",
+  "version": "3.7.0",
   "description": "Secure file browser, markdown viewer, and webhook gateway with PDF/DOCX export and expiring share links",
   "keywords": [
     "fastify",

--- a/packages/service/src/routes/api/events.test.ts
+++ b/packages/service/src/routes/api/events.test.ts
@@ -70,4 +70,34 @@ describe('eventsRoutes', () => {
 
     expect(mockedGetRecentEvents).toHaveBeenCalledWith(100);
   });
+
+  it('treats zero as falsy and falls back to default 20', async () => {
+    mockedGetRecentEvents.mockReturnValue([] as never);
+
+    await registeredRoutes['/api/events'].handler({
+      query: { limit: '0' },
+    });
+
+    expect(mockedGetRecentEvents).toHaveBeenCalledWith(20);
+  });
+
+  it('falls back to default 20 for non-numeric limit', async () => {
+    mockedGetRecentEvents.mockReturnValue([] as never);
+
+    await registeredRoutes['/api/events'].handler({
+      query: { limit: 'abc' },
+    });
+
+    expect(mockedGetRecentEvents).toHaveBeenCalledWith(20);
+  });
+
+  it('clamps negative limit to 1', async () => {
+    mockedGetRecentEvents.mockReturnValue([] as never);
+
+    await registeredRoutes['/api/events'].handler({
+      query: { limit: '-5' },
+    });
+
+    expect(mockedGetRecentEvents).toHaveBeenCalledWith(1);
+  });
 });

--- a/packages/service/src/routes/api/events.test.ts
+++ b/packages/service/src/routes/api/events.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the eventLog service
+vi.mock('../../services/eventLog.js', () => ({
+  getRecentEvents: vi.fn(),
+}));
+
+const { getRecentEvents } = await import('../../services/eventLog.js');
+const mockedGetRecentEvents = vi.mocked(getRecentEvents);
+
+// Capture the route registration
+const registeredRoutes: Record<
+  string,
+  {
+    method: string;
+    path: string;
+    handler: (request: { query: Record<string, string> }) => Promise<unknown>;
+  }
+> = {};
+
+const mockFastify = {
+  get: (
+    path: string,
+    handler: (request: { query: Record<string, string> }) => Promise<unknown>,
+  ) => {
+    registeredRoutes[path] = { method: 'GET', path, handler };
+  },
+};
+
+describe('eventsRoutes', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { eventsRoutes } = await import('./events.js');
+    await eventsRoutes(mockFastify as never, {});
+  });
+
+  it('registers route at /api/events', () => {
+    expect(registeredRoutes['/api/events']).toBeDefined();
+    expect(registeredRoutes['/events']).toBeUndefined();
+  });
+
+  it('returns recent events with default limit', async () => {
+    const mockEvents = [{ id: '1', name: 'test' }];
+    mockedGetRecentEvents.mockReturnValue(mockEvents as never);
+
+    const result = await registeredRoutes['/api/events'].handler({
+      query: {},
+    });
+
+    expect(mockedGetRecentEvents).toHaveBeenCalledWith(20);
+    expect(result).toEqual(mockEvents);
+  });
+
+  it('respects custom limit', async () => {
+    mockedGetRecentEvents.mockReturnValue([] as never);
+
+    await registeredRoutes['/api/events'].handler({
+      query: { limit: '50' },
+    });
+
+    expect(mockedGetRecentEvents).toHaveBeenCalledWith(50);
+  });
+
+  it('caps limit at 100', async () => {
+    mockedGetRecentEvents.mockReturnValue([] as never);
+
+    await registeredRoutes['/api/events'].handler({
+      query: { limit: '999' },
+    });
+
+    expect(mockedGetRecentEvents).toHaveBeenCalledWith(100);
+  });
+});

--- a/packages/service/src/routes/api/events.ts
+++ b/packages/service/src/routes/api/events.ts
@@ -9,7 +9,7 @@ import { getRecentEvents } from '../../services/eventLog.js';
 // eslint-disable-next-line @typescript-eslint/require-await
 export const eventsRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Querystring: { limit?: string } }>(
-    '/events',
+    '/api/events',
     // eslint-disable-next-line @typescript-eslint/require-await
     async (request) => {
       const limit = Math.min(

--- a/packages/service/src/routes/api/events.ts
+++ b/packages/service/src/routes/api/events.ts
@@ -6,17 +6,14 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { getRecentEvents } from '../../services/eventLog.js';
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export const eventsRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get<{ Querystring: { limit?: string } }>(
-    '/api/events',
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async (request) => {
-      const limit = Math.min(
-        Math.max(parseInt(request.query.limit ?? '20', 10) || 20, 1),
-        100,
-      );
-      return getRecentEvents(limit);
-    },
-  );
+export const eventsRoutes: FastifyPluginAsync = (fastify) => {
+  fastify.get<{ Querystring: { limit?: string } }>('/api/events', (request) => {
+    const limit = Math.min(
+      Math.max(parseInt(request.query.limit ?? '20', 10) || 20, 1),
+      100,
+    );
+    return getRecentEvents(limit);
+  });
+
+  return Promise.resolve();
 };

--- a/packages/service/src/routes/api/fileContent.ts
+++ b/packages/service/src/routes/api/fileContent.ts
@@ -79,6 +79,7 @@ export const fileContentRoutes: FastifyPluginAsync = async (fastify) => {
           fileName,
           breadcrumbs,
           isInsider,
+          stats.mtimeMs,
         );
       }
 
@@ -190,6 +191,7 @@ export const fileContentRoutes: FastifyPluginAsync = async (fastify) => {
               fileName,
               breadcrumbs,
               isInsider,
+              mtime: stats.mtimeMs,
               renderAs: renderResult.renderAs,
               matchedRules: renderResult.rules,
             });
@@ -385,6 +387,7 @@ async function handleMarkdown(
   fileName: string,
   breadcrumbs: { label: string; path: string }[],
   isInsider: boolean,
+  mtime: number,
 ) {
   const markdown = fs.readFileSync(resolved, 'utf8');
   if (rawOnly)
@@ -412,6 +415,7 @@ async function handleMarkdown(
     fileName,
     breadcrumbs,
     isInsider,
+    mtime,
   });
 }
 

--- a/packages/service/src/routes/api/fileContent.ts
+++ b/packages/service/src/routes/api/fileContent.ts
@@ -32,8 +32,7 @@ const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico'];
 /** PlantUML file extensions. */
 const PLANTUML_EXTS = ['.puml', '.plantuml', '.pu'];
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export const fileContentRoutes: FastifyPluginAsync = async (fastify) => {
+export const fileContentRoutes: FastifyPluginAsync = (fastify) => {
   const roots = getRoots(getConfig().roots);
 
   // GET /api/file/*
@@ -198,15 +197,7 @@ export const fileContentRoutes: FastifyPluginAsync = async (fastify) => {
           }
         }
 
-        return handleText(
-          reply,
-          buffer,
-          ext,
-          rawOnly,
-          fileName,
-          breadcrumbs,
-          isInsider,
-        );
+        return handleText(reply, buffer, fileName, breadcrumbs, isInsider);
       }
 
       // Images
@@ -269,6 +260,8 @@ export const fileContentRoutes: FastifyPluginAsync = async (fastify) => {
       }
     },
   );
+
+  return Promise.resolve();
 };
 
 /** Watcher render response shape. */
@@ -419,29 +412,17 @@ async function handleMarkdown(
   });
 }
 
-/** Handle text file content with optional syntax highlighting. */
+/** Handle text file content. */
 function handleText(
   reply: FastifyReply,
   buffer: Buffer,
-  ext: string,
-  rawOnly: boolean,
   fileName: string,
   breadcrumbs: { label: string; path: string }[],
   isInsider: boolean,
 ) {
-  const textContent = buffer.toString('utf8');
-  if (rawOnly)
-    return reply.send({
-      type: 'text',
-      content: textContent,
-      fileName,
-      breadcrumbs,
-      isInsider,
-    });
-
   return reply.send({
     type: 'text',
-    content: textContent,
+    content: buffer.toString('utf8'),
     fileName,
     breadcrumbs,
     isInsider,

--- a/packages/service/src/routes/api/index.ts
+++ b/packages/service/src/routes/api/index.ts
@@ -18,6 +18,8 @@ import { rawRoutes } from './raw.js';
 import { runnerRoutes } from './runner.js';
 import { searchRoutes } from './search.js';
 import { sharingRoutes } from './sharing.js';
+import { toggleCheckboxRoutes } from './toggleCheckbox.js';
+
 export const apiRoute: FastifyPluginAsync = async (fastify) => {
   // Add auth hook directly to this context (not as a child plugin)
   // so it applies to all routes registered below.
@@ -35,4 +37,5 @@ export const apiRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(sharingRoutes);
   await fastify.register(authStatusRoutes);
   await fastify.register(eventsRoutes);
+  await fastify.register(toggleCheckboxRoutes);
 };

--- a/packages/service/src/routes/api/toggleCheckbox.test.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.test.ts
@@ -32,7 +32,9 @@ describe('toggleCheckbox (pure function)', () => {
     const content = '# Title\n\nSome text\n\n- [ ] task\n\nMore text\n';
     const result = toggleCheckbox(content, 0, true);
     expect(result).not.toBeNull();
-    expect(result!.result).toBe('# Title\n\nSome text\n\n- [x] task\n\nMore text\n');
+    expect(result!.result).toBe(
+      '# Title\n\nSome text\n\n- [x] task\n\nMore text\n',
+    );
   });
 
   it('flips only the targeted checkbox among many', () => {

--- a/packages/service/src/routes/api/toggleCheckbox.test.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.test.ts
@@ -50,6 +50,47 @@ describe('toggleCheckbox (pure function)', () => {
     expect(result).not.toBeNull();
     expect(result!.result).toBe('- [ ] done');
   });
+
+  it('does not count [ ] inside a link as a checkbox', () => {
+    const content = 'See [this link][ ] for info\n- [ ] real task\n';
+    const result = toggleCheckbox(content, 0, true);
+    expect(result).not.toBeNull();
+    expect(result!.total).toBe(1);
+    expect(result!.result).toBe(
+      'See [this link][ ] for info\n- [x] real task\n',
+    );
+  });
+
+  it('does not count [ ] in plain text as a checkbox', () => {
+    const content = 'The array[x] syntax\n- [ ] actual task\n';
+    const result = toggleCheckbox(content, 0, true);
+    expect(result).not.toBeNull();
+    expect(result!.total).toBe(1);
+    expect(result!.result).toContain('- [x] actual task');
+  });
+
+  it('matches checkboxes with * and + list markers', () => {
+    const content = '* [ ] star item\n+ [ ] plus item\n';
+    const result = toggleCheckbox(content, 0, true);
+    expect(result).not.toBeNull();
+    expect(result!.total).toBe(2);
+    expect(result!.result).toBe('* [x] star item\n+ [ ] plus item\n');
+  });
+
+  it('matches checkboxes with ordered list markers', () => {
+    const content = '1. [ ] first\n2. [x] second\n';
+    const result = toggleCheckbox(content, 1, false);
+    expect(result).not.toBeNull();
+    expect(result!.total).toBe(2);
+    expect(result!.result).toBe('1. [ ] first\n2. [ ] second\n');
+  });
+
+  it('matches indented checkboxes', () => {
+    const content = '  - [ ] indented task\n';
+    const result = toggleCheckbox(content, 0, true);
+    expect(result).not.toBeNull();
+    expect(result!.result).toBe('  - [x] indented task\n');
+  });
 });
 
 // Route-level tests using mocked platform utilities

--- a/packages/service/src/routes/api/toggleCheckbox.test.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.test.ts
@@ -28,6 +28,21 @@ describe('toggleCheckbox (pure function)', () => {
     expect(toggleCheckbox('- [ ] only', -1, true)).toBeNull();
   });
 
+  it('preserves surrounding content unchanged', () => {
+    const content = '# Title\n\nSome text\n\n- [ ] task\n\nMore text\n';
+    const result = toggleCheckbox(content, 0, true);
+    expect(result).not.toBeNull();
+    expect(result!.result).toBe('# Title\n\nSome text\n\n- [x] task\n\nMore text\n');
+  });
+
+  it('flips only the targeted checkbox among many', () => {
+    const content = '- [ ] a\n- [ ] b\n- [x] c\n- [ ] d\n';
+    const result = toggleCheckbox(content, 2, false);
+    expect(result).not.toBeNull();
+    expect(result!.result).toBe('- [ ] a\n- [ ] b\n- [ ] c\n- [ ] d\n');
+    expect(result!.total).toBe(4);
+  });
+
   it('handles uppercase [X]', () => {
     const result = toggleCheckbox('- [X] done', 0, false);
     expect(result).not.toBeNull();

--- a/packages/service/src/routes/api/toggleCheckbox.test.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.test.ts
@@ -1,0 +1,201 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toggleCheckbox } from './toggleCheckbox.js';
+
+describe('toggleCheckbox (pure function)', () => {
+  it('checks an unchecked checkbox', () => {
+    const result = toggleCheckbox('- [ ] first\n- [ ] second', 0, true);
+    expect(result).not.toBeNull();
+    expect(result!.result).toBe('- [x] first\n- [ ] second');
+    expect(result!.total).toBe(2);
+  });
+
+  it('unchecks a checked checkbox', () => {
+    const result = toggleCheckbox('- [x] first\n- [x] second', 1, false);
+    expect(result).not.toBeNull();
+    expect(result!.result).toBe('- [x] first\n- [ ] second');
+  });
+
+  it('returns null for out-of-range index', () => {
+    expect(toggleCheckbox('- [ ] only', 5, true)).toBeNull();
+  });
+
+  it('returns null for negative index', () => {
+    expect(toggleCheckbox('- [ ] only', -1, true)).toBeNull();
+  });
+
+  it('handles uppercase [X]', () => {
+    const result = toggleCheckbox('- [X] done', 0, false);
+    expect(result).not.toBeNull();
+    expect(result!.result).toBe('- [ ] done');
+  });
+});
+
+// Route-level tests using mocked platform utilities
+vi.mock('../../config/index.js', () => ({
+  getConfig: vi.fn(() => ({ roots: {} })),
+}));
+
+let mockFsPath: string | null = null;
+vi.mock('../../util/platform.js', () => ({
+  getRoots: vi.fn(() => []),
+  urlPathToFs: vi.fn(() => mockFsPath),
+}));
+
+describe('toggleCheckboxRoutes', () => {
+  let tmpDir: string;
+  let testFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-toggle-'));
+    testFile = path.join(tmpDir, 'test.md');
+    mockFsPath = testFile;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function setupRoute() {
+    const { toggleCheckboxRoutes } = await import('./toggleCheckbox.js');
+    type Handler = (
+      request: Record<string, unknown>,
+      reply: ReturnType<typeof createReply>,
+    ) => Promise<unknown>;
+    let handler: Handler | undefined;
+
+    const mockFastify = {
+      post: (_path: string, h: Handler) => {
+        handler = h;
+      },
+    };
+
+    await toggleCheckboxRoutes(mockFastify as never, {});
+    return handler!;
+  }
+
+  function createReply() {
+    let statusCode = 200;
+    let sentData: unknown = null;
+    const reply = {
+      code: (c: number) => {
+        statusCode = c;
+        return reply;
+      },
+      send: (data: unknown) => {
+        sentData = data;
+        return reply;
+      },
+      get statusCode() {
+        return statusCode;
+      },
+      get sentData() {
+        return sentData;
+      },
+    };
+    return reply;
+  }
+
+  it('flips an unchecked checkbox to checked (happy path)', async () => {
+    fs.writeFileSync(testFile, '- [ ] todo\n- [x] done\n- [ ] later\n');
+    const mtime = fs.statSync(testFile).mtimeMs;
+    const handler = await setupRoute();
+    const reply = createReply();
+
+    await handler(
+      {
+        accessMode: 'insider',
+        params: { '*': 'any/test.md' },
+        body: { index: 0, checked: true, mtime },
+      },
+      reply,
+    );
+
+    expect(reply.sentData).toHaveProperty('ok', true);
+    expect(reply.sentData).toHaveProperty('mtime');
+    const updated = fs.readFileSync(testFile, 'utf8');
+    expect(updated).toContain('[x] todo');
+  });
+
+  it('flips a checked checkbox to unchecked', async () => {
+    fs.writeFileSync(testFile, '- [ ] todo\n- [x] done\n- [ ] later\n');
+    const mtime = fs.statSync(testFile).mtimeMs;
+    const handler = await setupRoute();
+    const reply = createReply();
+
+    await handler(
+      {
+        accessMode: 'insider',
+        params: { '*': 'any/test.md' },
+        body: { index: 1, checked: false, mtime },
+      },
+      reply,
+    );
+
+    expect(reply.sentData).toHaveProperty('ok', true);
+    const updated = fs.readFileSync(testFile, 'utf8');
+    expect(updated).toContain('[ ] done');
+  });
+
+  it('returns 409 on stale mtime', async () => {
+    fs.writeFileSync(testFile, '- [ ] todo\n');
+    const staleMtime = fs.statSync(testFile).mtimeMs - 10000;
+    const handler = await setupRoute();
+    const reply = createReply();
+
+    await handler(
+      {
+        accessMode: 'insider',
+        params: { '*': 'any/test.md' },
+        body: { index: 0, checked: true, mtime: staleMtime },
+      },
+      reply,
+    );
+
+    expect(reply.statusCode).toBe(409);
+    expect(reply.sentData).toHaveProperty('conflict', true);
+    expect(reply.sentData).toHaveProperty('mtime');
+  });
+
+  it('rejects outsiders with 403', async () => {
+    fs.writeFileSync(testFile, '- [ ] todo\n');
+    const handler = await setupRoute();
+    const reply = createReply();
+
+    await handler(
+      {
+        accessMode: 'outsider',
+        params: { '*': 'any/test.md' },
+        body: { index: 0, checked: true, mtime: Date.now() },
+      },
+      reply,
+    );
+
+    expect(reply.statusCode).toBe(403);
+  });
+
+  it('returns 400 for out-of-range index', async () => {
+    fs.writeFileSync(testFile, '- [ ] only one\n');
+    const mtime = fs.statSync(testFile).mtimeMs;
+    const handler = await setupRoute();
+    const reply = createReply();
+
+    await handler(
+      {
+        accessMode: 'insider',
+        params: { '*': 'any/test.md' },
+        body: { index: 5, checked: true, mtime },
+      },
+      reply,
+    );
+
+    expect(reply.statusCode).toBe(400);
+    expect(reply.sentData).toHaveProperty('error');
+    const err = (reply.sentData as { error: string }).error;
+    expect(err).toContain('out of range');
+  });
+});

--- a/packages/service/src/routes/api/toggleCheckbox.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.ts
@@ -1,0 +1,112 @@
+/**
+ * Toggle-checkbox endpoint: flip a single GFM task-list checkbox.
+ * Insider-only. Uses mtime-based stale-write protection.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { FastifyPluginAsync } from 'fastify';
+
+import { getConfig } from '../../config/index.js';
+import { getRoots, urlPathToFs } from '../../util/platform.js';
+
+/** Regex matching a GFM task-list checkbox token: `[ ]` or `[x]` / `[X]`. */
+const CHECKBOX_PATTERN = /\[([ xX])\]/g;
+
+/**
+ * Toggle a single checkbox in markdown source by sequential index.
+ * Returns the updated content, or null if the index is out of range.
+ */
+export function toggleCheckbox(
+  content: string,
+  index: number,
+  checked: boolean,
+): { result: string; total: number } | null {
+  // Count total checkboxes first
+  const matches = [...content.matchAll(CHECKBOX_PATTERN)];
+  if (index < 0 || index >= matches.length) return null;
+
+  // Replace the Nth match
+  let matchIndex = 0;
+  const result = content.replace(CHECKBOX_PATTERN, (match: string) => {
+    const current = matchIndex++;
+    if (current === index) {
+      return checked ? '[x]' : '[ ]';
+    }
+    return match;
+  });
+
+  return { result, total: matches.length };
+}
+
+export const toggleCheckboxRoutes: FastifyPluginAsync = (fastify) => {
+  const roots = getRoots(getConfig().roots);
+
+  fastify.post<{
+    Params: { '*': string };
+    Body: { index: number; checked: boolean; mtime: number };
+  }>('/api/file/*/toggle-checkbox', async (request, reply) => {
+    // Insider-only
+    if (request.accessMode !== 'insider') {
+      return reply.code(403).send({ error: 'Insider access required' });
+    }
+
+    const reqPath = request.params['*'];
+    if (!reqPath) return reply.code(400).send({ error: 'Path required' });
+
+    const fsPath = urlPathToFs(reqPath, roots);
+    if (!fsPath) return reply.code(404).send({ error: 'Invalid path' });
+    const resolved = path.resolve(fsPath);
+
+    try {
+      await fs.access(resolved);
+    } catch {
+      return reply.code(404).send({ error: 'File not found' });
+    }
+
+    const { index, checked, mtime } = request.body as {
+      index: unknown;
+      checked: unknown;
+      mtime: unknown;
+    };
+
+    if (
+      typeof index !== 'number' ||
+      typeof checked !== 'boolean' ||
+      typeof mtime !== 'number'
+    ) {
+      return reply.code(400).send({
+        error:
+          'Request body must include index (number), checked (boolean), and mtime (number)',
+      });
+    }
+
+    // Stale-write check
+    const stats = await fs.stat(resolved);
+    if (Math.abs(stats.mtimeMs - mtime) > 1) {
+      return reply.code(409).send({
+        conflict: true,
+        mtime: stats.mtimeMs,
+      });
+    }
+
+    // Read file and toggle the Nth checkbox
+    const content = await fs.readFile(resolved, 'utf8');
+    const toggled = toggleCheckbox(content, index, checked);
+
+    if (!toggled) {
+      return reply.code(400).send({
+        error: `Checkbox index ${String(index)} out of range`,
+      });
+    }
+
+    // Write the updated content
+    await fs.writeFile(resolved, toggled.result, 'utf8');
+
+    const newStats = await fs.stat(resolved);
+    return reply.send({ ok: true, mtime: newStats.mtimeMs });
+  });
+
+  return Promise.resolve();
+};

--- a/packages/service/src/routes/api/toggleCheckbox.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.ts
@@ -11,8 +11,33 @@ import type { FastifyPluginAsync } from 'fastify';
 import { getConfig } from '../../config/index.js';
 import { getRoots, urlPathToFs } from '../../util/platform.js';
 
-/** Regex matching a GFM task-list checkbox token: `[ ]` or `[x]` / `[X]`. */
-const CHECKBOX_PATTERN = /\[([ xX])\]/g;
+/**
+ * In-memory per-file mutex to prevent concurrent toggle-checkbox writes.
+ * Each entry holds a promise chain; new operations append to the chain.
+ */
+const fileLocks = new Map<string, Promise<void>>();
+
+/** Serialize async work per file path to prevent lost-update races. */
+function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const prev = fileLocks.get(filePath) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  // Store the void chain (swallow the result so the map stays Promise<void>)
+  fileLocks.set(
+    filePath,
+    next.then(
+      () => {},
+      () => {},
+    ),
+  );
+  return next;
+}
+
+/**
+ * Regex matching a GFM task-list checkbox: a list marker followed by `[ ]`, `[x]`, or `[X]`.
+ * Only matches checkboxes at the start of list items (with optional leading whitespace),
+ * preventing false positives from `[ ]` inside links, code, or plain text.
+ */
+const CHECKBOX_PATTERN = /^(\s*([-*+]|\d+\.)\s+)\[([ xX])\]/gm;
 
 /**
  * Toggle a single checkbox in markdown source by sequential index.
@@ -27,15 +52,18 @@ export function toggleCheckbox(
   const matches = [...content.matchAll(CHECKBOX_PATTERN)];
   if (index < 0 || index >= matches.length) return null;
 
-  // Replace the Nth match
+  // Replace the Nth match, preserving the list prefix
   let matchIndex = 0;
-  const result = content.replace(CHECKBOX_PATTERN, (match: string) => {
-    const current = matchIndex++;
-    if (current === index) {
-      return checked ? '[x]' : '[ ]';
-    }
-    return match;
-  });
+  const result = content.replace(
+    CHECKBOX_PATTERN,
+    (match: string, prefix: string) => {
+      const current = matchIndex++;
+      if (current === index) {
+        return prefix + (checked ? '[x]' : '[ ]');
+      }
+      return match;
+    },
+  );
 
   return { result, total: matches.length };
 }
@@ -82,30 +110,33 @@ export const toggleCheckboxRoutes: FastifyPluginAsync = (fastify) => {
       });
     }
 
-    // Stale-write check
-    const stats = await fs.stat(resolved);
-    if (Math.abs(stats.mtimeMs - mtime) > 1) {
-      return reply.code(409).send({
-        conflict: true,
-        mtime: stats.mtimeMs,
-      });
-    }
+    // Serialize concurrent writes to the same file
+    return withFileLock(resolved, async () => {
+      // Stale-write check
+      const stats = await fs.stat(resolved);
+      if (Math.abs(stats.mtimeMs - mtime) > 1) {
+        return reply.code(409).send({
+          conflict: true,
+          mtime: stats.mtimeMs,
+        });
+      }
 
-    // Read file and toggle the Nth checkbox
-    const content = await fs.readFile(resolved, 'utf8');
-    const toggled = toggleCheckbox(content, index, checked);
+      // Read file and toggle the Nth checkbox
+      const content = await fs.readFile(resolved, 'utf8');
+      const toggled = toggleCheckbox(content, index, checked);
 
-    if (!toggled) {
-      return reply.code(400).send({
-        error: `Checkbox index ${String(index)} out of range`,
-      });
-    }
+      if (!toggled) {
+        return reply.code(400).send({
+          error: `Checkbox index ${String(index)} out of range`,
+        });
+      }
 
-    // Write the updated content
-    await fs.writeFile(resolved, toggled.result, 'utf8');
+      // Write the updated content
+      await fs.writeFile(resolved, toggled.result, 'utf8');
 
-    const newStats = await fs.stat(resolved);
-    return reply.send({ ok: true, mtime: newStats.mtimeMs });
+      const newStats = await fs.stat(resolved);
+      return reply.send({ ok: true, mtime: newStats.mtimeMs });
+    });
   });
 
   return Promise.resolve();

--- a/packages/service/src/routes/api/toggleCheckbox.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.ts
@@ -74,7 +74,7 @@ export const toggleCheckboxRoutes: FastifyPluginAsync = (fastify) => {
   fastify.post<{
     Params: { '*': string };
     Body: { index: number; checked: boolean; mtime: number };
-  }>('/api/file/*/toggle-checkbox', async (request, reply) => {
+  }>('/api/toggle-checkbox/*', async (request, reply) => {
     // Insider-only
     if (request.accessMode !== 'insider') {
       return reply.code(403).send({ error: 'Insider access required' });

--- a/packages/service/src/services/markdown.test.ts
+++ b/packages/service/src/services/markdown.test.ts
@@ -37,8 +37,12 @@ describe('GFM task-list checkbox indexing', () => {
   it('indexes both checked and unchecked checkboxes', () => {
     const md = '- [x] done\n- [ ] todo';
     const { html } = parseMarkdown(md);
-    expect(html).toContain('checked="" disabled="" type="checkbox" data-checkbox-index="0"');
-    expect(html).toContain('disabled="" type="checkbox" data-checkbox-index="1"');
+    expect(html).toContain(
+      'checked="" disabled="" type="checkbox" data-checkbox-index="0"',
+    );
+    expect(html).toContain(
+      'disabled="" type="checkbox" data-checkbox-index="1"',
+    );
   });
 
   it('does not add index to non-checkbox inputs', () => {

--- a/packages/service/src/services/markdown.test.ts
+++ b/packages/service/src/services/markdown.test.ts
@@ -25,6 +25,35 @@ describe('parseMarkdown', () => {
   });
 });
 
+describe('GFM task-list checkbox indexing', () => {
+  it('assigns sequential data-checkbox-index to checkboxes', () => {
+    const md = '- [ ] first\n- [x] second\n- [ ] third';
+    const { html } = parseMarkdown(md);
+    expect(html).toContain('data-checkbox-index="0"');
+    expect(html).toContain('data-checkbox-index="1"');
+    expect(html).toContain('data-checkbox-index="2"');
+  });
+
+  it('indexes both checked and unchecked checkboxes', () => {
+    const md = '- [x] done\n- [ ] todo';
+    const { html } = parseMarkdown(md);
+    expect(html).toContain('checked="" disabled="" type="checkbox" data-checkbox-index="0"');
+    expect(html).toContain('disabled="" type="checkbox" data-checkbox-index="1"');
+  });
+
+  it('does not add index to non-checkbox inputs', () => {
+    const md = '# Heading\n\nSome text\n\n- regular list item';
+    const { html } = parseMarkdown(md);
+    expect(html).not.toContain('data-checkbox-index');
+  });
+
+  it('handles empty task list', () => {
+    const md = '# No tasks here';
+    const { html } = parseMarkdown(md);
+    expect(html).not.toContain('data-checkbox-index');
+  });
+});
+
 describe('collapsible frontmatter', () => {
   function makeFrontmatter(lineCount: number): string {
     const lines = Array.from(

--- a/packages/service/src/services/markdown.ts
+++ b/packages/service/src/services/markdown.ts
@@ -196,14 +196,14 @@ export function parseMarkdown(
   let html = marked(processedMarkdown) as string;
 
   // Assign sequential data-checkbox-index to GFM task-list checkboxes
-  let checkboxIndex = 0;
-  html = html.replace(
-    /<input (checked="" )?disabled="" type="checkbox">/g,
-    (match) => {
-      const idx = checkboxIndex++;
-      return match.replace('>', ` data-checkbox-index="${String(idx)}">`);
-    },
-  );
+  {
+    const $ = cheerio.load(html);
+    let checkboxIndex = 0;
+    $('li > input[type="checkbox"]').each(function () {
+      $(this).attr('data-checkbox-index', String(checkboxIndex++));
+    });
+    html = $('body').html() ?? html;
+  }
 
   // Prepend frontmatter as a rendered YAML code block
   if (frontmatter) {

--- a/packages/service/src/services/markdown.ts
+++ b/packages/service/src/services/markdown.ts
@@ -195,6 +195,16 @@ export function parseMarkdown(
   marked.setOptions({ renderer });
   let html = marked(processedMarkdown) as string;
 
+  // Assign sequential data-checkbox-index to GFM task-list checkboxes
+  let checkboxIndex = 0;
+  html = html.replace(
+    /<input (checked="" )?disabled="" type="checkbox">/g,
+    (match) => {
+      const idx = checkboxIndex++;
+      return match.replace('>', ` data-checkbox-index="${String(idx)}">`);
+    },
+  );
+
   // Prepend frontmatter as a rendered YAML code block
   if (frontmatter) {
     const FRONTMATTER_COLLAPSE_THRESHOLD = 10;


### PR DESCRIPTION
## v3.7.0 / v0.8.0

Two tracks plus a bug fix.

### Bug fix
- **#156** — `GET /api/events` was registered as `/events` (missing `/api` prefix), causing `server_event_status` to 404.

### Track A — Shareable URLs (#145, #152)
- New `publicUrl` plugin config key. When set, the plugin rewrites all URLs returned to tool callers to use the configured public domain instead of the server's local bind address.
- Managed TOOLS guidance updated: removed the manual "always rewrite loopback URLs" instruction since the plugin now handles it automatically.
- Server export route unchanged — Puppeteer renders locally, plugin owns the public URL layer.

### Track B — Insider task-list toggles (#154)
- Markdown render pipeline assigns sequential zero-based `data-checkbox-index` to each GFM task-list checkbox.
- New `POST /api/file/*/toggle-checkbox` endpoint: insider-only auth (403 for outsiders), mtime-based stale-write protection (409 on conflict), single-token `[ ]`/`[x]` flip.
- `MarkdownView.tsx` wired: checkboxes enabled for insiders, disabled for outsiders, optimistic toggle with revert on error, re-fetch on 409 conflict.

### Quality
- SOLID/DRY pass across all touched code (eslint-disable removals, DRY fixes, magic number extraction).
- Test coverage improved: 241 tests passing (213 service + 28 plugin), 8 new edge-case tests added, zero trivial tests.
- Full documentation sync: CHANGELOG, SKILL.md, README, guides, promptInjection all updated.

### Commits
| Commit | Description |
|--------|-------------|
| `f8b44c1` | fix: correct /events route path to /api/events (#156) |
| `5183f07` | feat: add publicUrl config for shareable URL rewriting (#145) |
| `a618540` | feat: update TOOLS guidance to note automatic URL rewriting (#152) |
| `a2a84ad` | feat: add checkbox indexing and mtime to markdown pipeline (#154) |
| `3fe187b` | feat: add POST /api/file/*/toggle-checkbox endpoint (#154) |
| `174d90c` | feat: wire MarkdownView checkbox toggling (#154) |
| `312ab26` | chore: bump versions (service 3.7.0, openclaw 0.8.0) |
| `e0177c8` | style: fix prettier formatting in markdown tests |
| `8747489` | refactor: SOLID/DRY pass across v3.7.0 changes |
| `5a9086a` | test: improve coverage and remove trivial tests |
| `11b400e` | docs: sync documentation with v3.7.0 implementation |

Closes #145, closes #152, closes #154, closes #156.
