### PR TITLE
fix: post-merge checkbox toggle, Gemini review, CI wildcard

### DIFF
--- a/packages/service/client/src/components/MarkdownView.tsx
+++ b/packages/service/client/src/components/MarkdownView.tsx
@@ -113,13 +113,16 @@ export function MarkdownView({
     if (indexAttr === null) return;
     if (!isInsider) return;
 
-    e.preventDefault();
+    // Don't call e.preventDefault() — with dangerouslySetInnerHTML the browser
+    // has already toggled the native checkbox before this handler fires.
+    // Stop propagation to prevent any parent anchor/form from navigating.
+    e.stopPropagation();
+
     const index = parseInt(indexAttr, 10);
-    const checked = !input.checked; // Toggle the current state
+    // The browser already toggled input.checked to the desired new state.
+    const checked = input.checked;
 
     setToggling(true);
-    // Visually toggle immediately for responsiveness
-    input.checked = checked;
     input.disabled = true;
 
     try {


### PR DESCRIPTION
## Post-merge fixes for v3.7.0 / v0.8.0

Follow-up to #157 (merged). Addresses Gemini review feedback, CI failure, and a checkbox toggle click-handling bug found in production.

### Fixes

1. **Gemini review items** (`718b60a`)
   - URL origin boundary check: prevents false positive matching (e.g. `:1934` matching `:19345`)
   - GFM-only checkbox regex: only matches actual list items, not `[ ]` inside links/code/text
   - Race condition: in-memory per-file mutex via `withFileLock()`
   - Cheerio for checkbox indexing: replaces brittle regex-based HTML modification

2. **CI failure** (`34a0cbd`)
   - Toggle-checkbox route used wildcard in middle of path (`/api/file/*/toggle-checkbox`) which crashes Fastify's `find-my-way` router
   - Moved to `POST /api/toggle-checkbox/*` (wildcard at end)

3. **Checkbox click handling** (`49a49d8`)
   - With `dangerouslySetInnerHTML`, browser toggles checkbox state *before* React's click handler fires
   - `e.preventDefault()` had no effect on already-toggled native DOM checkboxes → replaced with `e.stopPropagation()`
   - `!input.checked` was sending the *old* state instead of the new desired state → changed to `input.checked`
   - This fixes: checked boxes appearing to work but not changing state, unchecked boxes doing nothing

### Test changes
- 10 new tests for URL boundary edge cases and GFM-only checkbox regex
- All 251 tests pass
