### PR TITLE
fix: checkbox indexing for loose list items

### DIFF
--- a/packages/service/src/services/markdown.ts
+++ b/packages/service/src/services/markdown.ts
@@ -199,7 +199,7 @@ export function parseMarkdown(
   {
     const $ = cheerio.load(html);
     let checkboxIndex = 0;
-    $('li > input[type="checkbox"]').each(function () {
+    $('li input[type="checkbox"]').each(function () {
       $(this).attr('data-checkbox-index', String(checkboxIndex++));
     });
     html = $('body').html() ?? html;


### PR DESCRIPTION
The Cheerio selector `li > input[type="checkbox"]` only matches direct children of `<li>`. But `marked` wraps loose list items in `<p>` tags, producing `<li><p><input>` — so the selector misses them.

Changed to descendant selector `li input[type="checkbox"]` which matches both tight (`<li><input>`) and loose (`<li><p><input>`) list items.

**Verified locally** — both tight and loose checkboxes toggle correctly in both directions (check and uncheck).
