### PR TITLE
refactor: simplify checkbox toggle to fire-and-forget

### DIFF
--- a/packages/service/client/src/components/FileContentView.tsx
+++ b/packages/service/client/src/components/FileContentView.tsx
@@ -30,7 +30,6 @@ interface FileContentViewProps {
   mobileTocOpen: boolean;
   setMobileTocOpen: (open: boolean) => void;
   onSave: (content: string) => Promise<void>;
-  onRefetch: () => void;
   loading: boolean;
 }
 
@@ -40,7 +39,6 @@ export function FileContentView({
   proseWidth, topBarHeight, mainRef,
   mobileTocOpen, setMobileTocOpen,
   onSave,
-  onRefetch,
 }: FileContentViewProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   useScrollAnchor(mainRef, contentRef);
@@ -110,7 +108,6 @@ export function FileContentView({
         <MarkdownView
           fileRendered={fileRendered}
           reqPath={reqPath}
-          onRefetch={onRefetch}
           proseWidth={proseWidth}
           topBarHeight={topBarHeight}
           mainRef={mainRef}

--- a/packages/service/client/src/components/MarkdownView.tsx
+++ b/packages/service/client/src/components/MarkdownView.tsx
@@ -18,7 +18,6 @@ import { scrollToIdInContainer } from './scrollUtils';
 interface MarkdownViewProps {
   fileRendered: FileContent;
   reqPath: string;
-  onRefetch: () => void;
   proseWidth: 'narrow' | 'medium' | 'wide';
   topBarHeight: number;
   mainRef: React.RefObject<HTMLElement | null>;
@@ -27,21 +26,13 @@ interface MarkdownViewProps {
 }
 
 export function MarkdownView({
-  fileRendered, reqPath, onRefetch, proseWidth, topBarHeight, mainRef,
+  fileRendered, reqPath, proseWidth, topBarHeight, mainRef,
   mobileTocOpen, setMobileTocOpen,
 }: MarkdownViewProps) {
   const [theme] = useTheme();
   const plainCode = new URLSearchParams(window.location.search).has('plain_code');
   const hasHeadings = fileRendered.headings && fileRendered.headings.length > 2;
   const articleRef = useRef<HTMLElement | null>(null);
-  const mtimeRef = useRef<number>(fileRendered.mtime ?? 0);
-
-  // Update mtime when fileRendered changes (e.g. after refetch)
-  useEffect(() => {
-    if (fileRendered.mtime !== undefined) {
-      mtimeRef.current = fileRendered.mtime;
-    }
-  }, [fileRendered.mtime]);
 
   const isInsider = fileRendered.isInsider;
 
@@ -86,15 +77,6 @@ export function MarkdownView({
     [scrollToHeading, setMobileTocOpen],
   );
 
-  // Stable refs for the event delegation handler to close over.
-  // This avoids re-attaching the listener when these values change.
-  const reqPathRef = useRef(reqPath);
-  reqPathRef.current = reqPath;
-  const onRefetchRef = useRef(onRefetch);
-  onRefetchRef.current = onRefetch;
-  const isInsiderRef = useRef(isInsider);
-  isInsiderRef.current = isInsider;
-
   // Enable/disable checkboxes when insider status or HTML changes
   useEffect(() => {
     const el = articleRef.current;
@@ -106,42 +88,28 @@ export function MarkdownView({
     });
   }, [fileRendered.html, isInsider]);
 
-  // Checkbox click handler — attached in the ref callback below.
-  // Stored in a ref so the inline ref callback doesn't recreate it.
-  const checkboxHandlerRef = useRef<((evt: Event) => void) | null>(null);
-  if (!checkboxHandlerRef.current) {
-    checkboxHandlerRef.current = (evt: Event) => {
-      const target = evt.target as HTMLElement;
-      if (target.tagName !== 'INPUT' || (target as HTMLInputElement).type !== 'checkbox') return;
-      const input = target as HTMLInputElement;
-      const indexAttr = input.getAttribute('data-checkbox-index');
+  // Fire-and-forget checkbox toggle via 'change' event
+  useEffect(() => {
+    const el = articleRef.current;
+    if (!el || !isInsider) return;
+
+    const checkboxes = el.querySelectorAll<HTMLInputElement>('input[type="checkbox"][data-checkbox-index]');
+
+    function handleChange(this: HTMLInputElement) {
+      const indexAttr = this.getAttribute('data-checkbox-index');
       if (indexAttr === null) return;
-      if (!isInsiderRef.current) return;
-
-      evt.preventDefault();
-      evt.stopPropagation();
-
       const index = parseInt(indexAttr, 10);
-      const desired = !input.checked;
+      const checked = this.checked;
+      toggleCheckbox(reqPath, index, checked).catch(() =>
+        console.warn('Checkbox toggle failed for index', index),
+      );
+    }
 
-      input.disabled = true;
-      toggleCheckbox(reqPathRef.current, index, desired, mtimeRef.current)
-        .then((result) => {
-          if (result.conflict) {
-            onRefetchRef.current();
-          } else if (result.ok) {
-            input.checked = desired;
-            mtimeRef.current = result.mtime;
-          }
-        })
-        .catch(() => {
-          // Server error — leave checkbox unchanged
-        })
-        .finally(() => {
-          input.disabled = false;
-        });
+    checkboxes.forEach((cb) => cb.addEventListener('change', handleChange));
+    return () => {
+      checkboxes.forEach((cb) => cb.removeEventListener('change', handleChange));
     };
-  }
+  }, [fileRendered.html, isInsider, reqPath]);
 
   return (
     <>
@@ -193,16 +161,8 @@ export function MarkdownView({
         {/* Markdown article */}
         <article
           ref={(el) => {
-            // Remove handler from previous element if it changed
-            if (articleRef.current && articleRef.current !== el && checkboxHandlerRef.current) {
-              articleRef.current.removeEventListener('click', checkboxHandlerRef.current, true);
-            }
             articleRef.current = el;
             if (el) {
-              // Attach checkbox handler in capture phase
-              if (checkboxHandlerRef.current) {
-                el.addEventListener('click', checkboxHandlerRef.current, true);
-              }
               if (!plainCode) initCodeBlockCm6(el, theme);
               injectCopyButtons(el);
               initInlineSvgPanzoom(el);

--- a/packages/service/client/src/components/MarkdownView.tsx
+++ b/packages/service/client/src/components/MarkdownView.tsx
@@ -34,7 +34,6 @@ export function MarkdownView({
   const plainCode = new URLSearchParams(window.location.search).has('plain_code');
   const hasHeadings = fileRendered.headings && fileRendered.headings.length > 2;
   const articleRef = useRef<HTMLElement | null>(null);
-  const [toggling, setToggling] = useState(false);
   const mtimeRef = useRef<number>(fileRendered.mtime ?? 0);
 
   // Update mtime when fileRendered changes (e.g. after refetch)
@@ -87,60 +86,62 @@ export function MarkdownView({
     [scrollToHeading, setMobileTocOpen],
   );
 
-  // Setup checkbox interactivity after render
+  // Stable refs for the event delegation handler to close over.
+  // This avoids re-attaching the listener when these values change.
+  const reqPathRef = useRef(reqPath);
+  reqPathRef.current = reqPath;
+  const onRefetchRef = useRef(onRefetch);
+  onRefetchRef.current = onRefetch;
+  const isInsiderRef = useRef(isInsider);
+  isInsiderRef.current = isInsider;
+
+  // Enable/disable checkboxes when insider status or HTML changes
   useEffect(() => {
     const el = articleRef.current;
     if (!el) return;
-
     const checkboxes = el.querySelectorAll<HTMLInputElement>('input[type="checkbox"][data-checkbox-index]');
     checkboxes.forEach((cb) => {
-      if (isInsider && !toggling) {
-        cb.disabled = false;
-        cb.style.cursor = 'pointer';
-      } else {
-        cb.disabled = true;
-        cb.style.cursor = '';
-      }
+      cb.disabled = !isInsider;
+      cb.style.cursor = isInsider ? 'pointer' : '';
     });
-  }, [fileRendered.html, isInsider, toggling]);
+  }, [fileRendered.html, isInsider]);
 
-  const handleCheckboxClick = useCallback(async (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    if (target.tagName !== 'INPUT' || (target as HTMLInputElement).type !== 'checkbox') return;
+  // Checkbox click handler — attached in the ref callback below.
+  // Stored in a ref so the inline ref callback doesn't recreate it.
+  const checkboxHandlerRef = useRef<((evt: Event) => void) | null>(null);
+  if (!checkboxHandlerRef.current) {
+    checkboxHandlerRef.current = (evt: Event) => {
+      const target = evt.target as HTMLElement;
+      if (target.tagName !== 'INPUT' || (target as HTMLInputElement).type !== 'checkbox') return;
+      const input = target as HTMLInputElement;
+      const indexAttr = input.getAttribute('data-checkbox-index');
+      if (indexAttr === null) return;
+      if (!isInsiderRef.current) return;
 
-    const input = target as HTMLInputElement;
-    const indexAttr = input.getAttribute('data-checkbox-index');
-    if (indexAttr === null) return;
-    if (!isInsider) return;
+      evt.preventDefault();
+      evt.stopPropagation();
 
-    // Don't call e.preventDefault() — with dangerouslySetInnerHTML the browser
-    // has already toggled the native checkbox before this handler fires.
-    // Stop propagation to prevent any parent anchor/form from navigating.
-    e.stopPropagation();
+      const index = parseInt(indexAttr, 10);
+      const desired = !input.checked;
 
-    const index = parseInt(indexAttr, 10);
-    // The browser already toggled input.checked to the desired new state.
-    const checked = input.checked;
-
-    setToggling(true);
-    input.disabled = true;
-
-    try {
-      const result = await toggleCheckbox(reqPath, index, checked, mtimeRef.current);
-
-      if (result.conflict) {
-        // Stale write - refetch
-        onRefetch();
-      } else if (result.ok) {
-        mtimeRef.current = result.mtime;
-      }
-    } catch {
-      // Revert the visual toggle on error
-      input.checked = !checked;
-    } finally {
-      setToggling(false);
-    }
-  }, [isInsider, reqPath, onRefetch]);
+      input.disabled = true;
+      toggleCheckbox(reqPathRef.current, index, desired, mtimeRef.current)
+        .then((result) => {
+          if (result.conflict) {
+            onRefetchRef.current();
+          } else if (result.ok) {
+            input.checked = desired;
+            mtimeRef.current = result.mtime;
+          }
+        })
+        .catch(() => {
+          // Server error — leave checkbox unchanged
+        })
+        .finally(() => {
+          input.disabled = false;
+        });
+    };
+  }
 
   return (
     <>
@@ -192,8 +193,16 @@ export function MarkdownView({
         {/* Markdown article */}
         <article
           ref={(el) => {
+            // Remove handler from previous element if it changed
+            if (articleRef.current && articleRef.current !== el && checkboxHandlerRef.current) {
+              articleRef.current.removeEventListener('click', checkboxHandlerRef.current, true);
+            }
             articleRef.current = el;
             if (el) {
+              // Attach checkbox handler in capture phase
+              if (checkboxHandlerRef.current) {
+                el.addEventListener('click', checkboxHandlerRef.current, true);
+              }
               if (!plainCode) initCodeBlockCm6(el, theme);
               injectCopyButtons(el);
               initInlineSvgPanzoom(el);
@@ -221,12 +230,6 @@ export function MarkdownView({
           dangerouslySetInnerHTML={{ __html: fileRendered.html! }}
           onClick={(e) => {
             const target = e.target as HTMLElement;
-
-            // Handle checkbox clicks
-            if (target.tagName === 'INPUT' && (target as HTMLInputElement).type === 'checkbox') {
-              void handleCheckboxClick(e);
-              return;
-            }
 
             // Handle anchor clicks
             const anchor = target.closest('a');

--- a/packages/service/client/src/hooks/useFileBrowser.ts
+++ b/packages/service/client/src/hooks/useFileBrowser.ts
@@ -41,7 +41,7 @@ export function useFileBrowser() {
     drives, directory, fileRaw, fileRendered, file,
     loading, error, editing, setEditing,
     viewTab, setViewTab: setViewTabInternal,
-    handleSave, refetchFile,
+    handleSave,
   } = useFileData(reqPath, searchParams);
 
   // Sync tab to URL
@@ -97,6 +97,6 @@ export function useFileBrowser() {
     rotateKeyDialogOpen, setRotateKeyDialogOpen,
     handleRotateKey, confirmRotateKey,
     topBarRef, mainRef, topBarHeight,
-    handleSave, refetchFile,
+    handleSave,
   };
 }

--- a/packages/service/client/src/hooks/useFileData.ts
+++ b/packages/service/client/src/hooks/useFileData.ts
@@ -70,17 +70,11 @@ export function useFileData(reqPath: string, searchParams: URLSearchParams) {
     setEditing(false);
   };
 
-  const refetchFile = useCallback(() => {
-    if (!reqPath) return;
-    getFileRaw(reqPath).then(setFileRaw).catch(() => {});
-    getFile(reqPath).then(setFileRendered).catch(() => {});
-  }, [reqPath]);
-
   return {
     drives, directory, fileRaw, fileRendered, file,
     loading, error,
     editing, setEditing,
     viewTab, setViewTab: setViewTabInternal,
-    handleSave, refetchFile,
+    handleSave,
   };
 }

--- a/packages/service/client/src/lib/api.ts
+++ b/packages/service/client/src/lib/api.ts
@@ -238,37 +238,16 @@ export async function fetchFacets(): Promise<FacetsResponse> {
   return fetchJson<FacetsResponse>(`${API_BASE}/search/facets`);
 }
 
-export interface ToggleCheckboxResult {
-  ok: boolean;
-  mtime: number;
-  conflict?: boolean;
-}
-
 export async function toggleCheckbox(
   filePath: string,
   index: number,
   checked: boolean,
-  mtime: number,
-): Promise<ToggleCheckboxResult> {
-  const url = withKey(`${API_BASE}/toggle-checkbox/${encodeBrowsePath(filePath)}`);
-  const res = await fetch(url, {
+): Promise<{ ok: boolean }> {
+  return fetchJson<{ ok: boolean }>(`${API_BASE}/toggle-checkbox/${encodeBrowsePath(filePath)}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ index, checked, mtime }),
-    credentials: 'same-origin',
+    body: JSON.stringify({ index, checked }),
   });
-
-  if (res.status === 409) {
-    const body = await res.json() as { conflict: boolean; mtime: number };
-    return { ok: false, conflict: true, mtime: body.mtime };
-  }
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Toggle failed: ${body}`);
-  }
-
-  return res.json() as Promise<ToggleCheckboxResult>;
 }
 
 export async function clearCache(path: string): Promise<{ cleared: { exports: number; diagrams: number } }> {

--- a/packages/service/client/src/pages/FileBrowser.tsx
+++ b/packages/service/client/src/pages/FileBrowser.tsx
@@ -24,7 +24,7 @@ export function FileBrowser() {
     rotateKeyDialogOpen, setRotateKeyDialogOpen,
     handleRotateKey, confirmRotateKey,
     topBarRef, mainRef, topBarHeight,
-    handleSave, refetchFile,
+    handleSave,
   } = useFileBrowser();
 
   const showFileView = file || (loading && !!reqPath);
@@ -117,7 +117,6 @@ export function FileBrowser() {
             mobileTocOpen={mobileTocOpen}
             setMobileTocOpen={setMobileTocOpen}
             onSave={handleSave}
-            onRefetch={refetchFile}
             loading={loading}
           />
         )}

--- a/packages/service/src/routes/api/toggleCheckbox.test.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.test.ts
@@ -160,7 +160,6 @@ describe('toggleCheckboxRoutes', () => {
 
   it('flips an unchecked checkbox to checked (happy path)', async () => {
     fs.writeFileSync(testFile, '- [ ] todo\n- [x] done\n- [ ] later\n');
-    const mtime = fs.statSync(testFile).mtimeMs;
     const handler = await setupRoute();
     const reply = createReply();
 
@@ -168,20 +167,18 @@ describe('toggleCheckboxRoutes', () => {
       {
         accessMode: 'insider',
         params: { '*': 'any/test.md' },
-        body: { index: 0, checked: true, mtime },
+        body: { index: 0, checked: true },
       },
       reply,
     );
 
     expect(reply.sentData).toHaveProperty('ok', true);
-    expect(reply.sentData).toHaveProperty('mtime');
     const updated = fs.readFileSync(testFile, 'utf8');
     expect(updated).toContain('[x] todo');
   });
 
   it('flips a checked checkbox to unchecked', async () => {
     fs.writeFileSync(testFile, '- [ ] todo\n- [x] done\n- [ ] later\n');
-    const mtime = fs.statSync(testFile).mtimeMs;
     const handler = await setupRoute();
     const reply = createReply();
 
@@ -189,7 +186,7 @@ describe('toggleCheckboxRoutes', () => {
       {
         accessMode: 'insider',
         params: { '*': 'any/test.md' },
-        body: { index: 1, checked: false, mtime },
+        body: { index: 1, checked: false },
       },
       reply,
     );
@@ -197,26 +194,6 @@ describe('toggleCheckboxRoutes', () => {
     expect(reply.sentData).toHaveProperty('ok', true);
     const updated = fs.readFileSync(testFile, 'utf8');
     expect(updated).toContain('[ ] done');
-  });
-
-  it('returns 409 on stale mtime', async () => {
-    fs.writeFileSync(testFile, '- [ ] todo\n');
-    const staleMtime = fs.statSync(testFile).mtimeMs - 10000;
-    const handler = await setupRoute();
-    const reply = createReply();
-
-    await handler(
-      {
-        accessMode: 'insider',
-        params: { '*': 'any/test.md' },
-        body: { index: 0, checked: true, mtime: staleMtime },
-      },
-      reply,
-    );
-
-    expect(reply.statusCode).toBe(409);
-    expect(reply.sentData).toHaveProperty('conflict', true);
-    expect(reply.sentData).toHaveProperty('mtime');
   });
 
   it('rejects outsiders with 403', async () => {
@@ -228,7 +205,7 @@ describe('toggleCheckboxRoutes', () => {
       {
         accessMode: 'outsider',
         params: { '*': 'any/test.md' },
-        body: { index: 0, checked: true, mtime: Date.now() },
+        body: { index: 0, checked: true },
       },
       reply,
     );
@@ -238,7 +215,6 @@ describe('toggleCheckboxRoutes', () => {
 
   it('returns 400 for out-of-range index', async () => {
     fs.writeFileSync(testFile, '- [ ] only one\n');
-    const mtime = fs.statSync(testFile).mtimeMs;
     const handler = await setupRoute();
     const reply = createReply();
 
@@ -246,7 +222,7 @@ describe('toggleCheckboxRoutes', () => {
       {
         accessMode: 'insider',
         params: { '*': 'any/test.md' },
-        body: { index: 5, checked: true, mtime },
+        body: { index: 5, checked: true },
       },
       reply,
     );

--- a/packages/service/src/routes/api/toggleCheckbox.ts
+++ b/packages/service/src/routes/api/toggleCheckbox.ts
@@ -1,6 +1,6 @@
 /**
  * Toggle-checkbox endpoint: flip a single GFM task-list checkbox.
- * Insider-only. Uses mtime-based stale-write protection.
+ * Insider-only. Fire-and-forget — last write wins.
  */
 
 import fs from 'node:fs/promises';
@@ -73,7 +73,7 @@ export const toggleCheckboxRoutes: FastifyPluginAsync = (fastify) => {
 
   fastify.post<{
     Params: { '*': string };
-    Body: { index: number; checked: boolean; mtime: number };
+    Body: { index: number; checked: boolean };
   }>('/api/toggle-checkbox/*', async (request, reply) => {
     // Insider-only
     if (request.accessMode !== 'insider') {
@@ -93,35 +93,23 @@ export const toggleCheckboxRoutes: FastifyPluginAsync = (fastify) => {
       return reply.code(404).send({ error: 'File not found' });
     }
 
-    const { index, checked, mtime } = request.body as {
+    const { index, checked } = request.body as {
       index: unknown;
       checked: unknown;
-      mtime: unknown;
     };
 
     if (
       typeof index !== 'number' ||
-      typeof checked !== 'boolean' ||
-      typeof mtime !== 'number'
+      typeof checked !== 'boolean'
     ) {
       return reply.code(400).send({
         error:
-          'Request body must include index (number), checked (boolean), and mtime (number)',
+          'Request body must include index (number) and checked (boolean)',
       });
     }
 
     // Serialize concurrent writes to the same file
     return withFileLock(resolved, async () => {
-      // Stale-write check
-      const stats = await fs.stat(resolved);
-      if (Math.abs(stats.mtimeMs - mtime) > 1) {
-        return reply.code(409).send({
-          conflict: true,
-          mtime: stats.mtimeMs,
-        });
-      }
-
-      // Read file and toggle the Nth checkbox
       const content = await fs.readFile(resolved, 'utf8');
       const toggled = toggleCheckbox(content, index, checked);
 
@@ -131,11 +119,8 @@ export const toggleCheckboxRoutes: FastifyPluginAsync = (fastify) => {
         });
       }
 
-      // Write the updated content
       await fs.writeFile(resolved, toggled.result, 'utf8');
-
-      const newStats = await fs.stat(resolved);
-      return reply.send({ ok: true, mtime: newStats.mtimeMs });
+      return reply.send({ ok: true });
     });
   });
 


### PR DESCRIPTION
## Simplify checkbox toggle to fire-and-forget

Replaces the complex mtime/conflict/preventDefault approach with a dead-simple pattern:

1. Browser toggles checkbox natively on click (no `preventDefault`)
2. `change` event fires → fire-and-forget POST to backend
3. Backend flips checkbox in file, returns `{ ok: true }`
4. No mtime, no 409 conflicts, no refs, no capture phase

**Net removal of 110 lines** across 8 files.

### Changes

- **MarkdownView.tsx** — Simple `useEffect` with `change` event listeners. No more mtime refs, capture-phase handlers, or complex lifecycle management.
- **toggleCheckbox.ts** — Removed mtime param and stale-write check. Just read → flip → write. Kept per-file mutex.
- **api.ts** — Removed mtime param, 409 handling, complex result type.
- **FileContentView, FileBrowser, useFileBrowser, useFileData** — Removed `onRefetch` prop plumbing entirely.
- **Tests** — Removed mtime/conflict tests, simplified assertions.
- **Spec** — Updated Decision 6 to "fire-and-forget, last-write-wins".

All 217 tests pass.
