### PR TITLE
fix: constrain edit popup height to prevent overflow

### DIFF
--- a/packages/service/client/src/components/BlockEditPopup.tsx
+++ b/packages/service/client/src/components/BlockEditPopup.tsx
@@ -106,7 +106,7 @@ export function BlockEditPopup({ mode, reqPath, blockLabel, fileContent, onClose
               if (e.key === 'Escape') onClose();
             }}
             rows={Math.max(2, Math.min(10, cellValue.split('\n').length))}
-            className="w-full px-3 py-2 border border-border rounded bg-background text-foreground text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+            className="w-full px-3 py-2 border border-border rounded bg-background text-foreground text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring max-h-[60vh] overflow-y-auto"
             disabled={cellSaving}
           />
           <div className="flex justify-end gap-2 mt-3">
@@ -156,7 +156,7 @@ export function BlockEditPopup({ mode, reqPath, blockLabel, fileContent, onClose
           </button>
           <span className="text-xs text-muted-foreground">Esc</span>
         </div>
-        <div className="flex-1 min-h-[200px] overflow-hidden">
+        <div className="flex-1 min-h-0 overflow-hidden">
           <Suspense
             fallback={
               <div className="flex items-center gap-2 text-muted-foreground text-sm py-8 justify-center">

--- a/packages/service/client/src/components/CodeEditor.tsx
+++ b/packages/service/client/src/components/CodeEditor.tsx
@@ -154,7 +154,7 @@ export function CodeEditor({
       )}
 
       {/* Editor */}
-      <div ref={containerRef} className="flex-1 overflow-hidden">
+      <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden">
         {loading && (
           <div className="flex items-center justify-center h-32 text-muted-foreground">
             Loading editor…

--- a/packages/service/client/src/components/LazyDiagram.ts
+++ b/packages/service/client/src/components/LazyDiagram.ts
@@ -53,8 +53,17 @@ async function loadDiagram(
     container.dataset.type = type;
     container.innerHTML = normalizedSvg;
 
+    // Preserve source mapping for block editing hover controls
+    const copySourceAttrs = (target: HTMLElement) => {
+      if (placeholder.dataset.sourceStart)
+        target.setAttribute('data-source-start', placeholder.dataset.sourceStart);
+      if (placeholder.dataset.sourceEnd)
+        target.setAttribute('data-source-end', placeholder.dataset.sourceEnd);
+    };
+
     const svg = container.querySelector('svg');
     if (!svg) {
+      copySourceAttrs(container);
       placeholder.replaceWith(container);
       return;
     }
@@ -64,6 +73,7 @@ async function loadDiagram(
       wrapperExtraClass: 'embedded-diagram-panzoom',
     });
 
+    copySourceAttrs(wrapper);
     placeholder.replaceWith(wrapper);
     initPanzoom();
     cleanups.push(cleanup);

--- a/packages/service/src/routes/api/fileMutations.ts
+++ b/packages/service/src/routes/api/fileMutations.ts
@@ -229,16 +229,21 @@ async function handleInsertBlock(
   body: InsertBlockBody,
   reply: MutationReply,
 ) {
-  const { atLine, position, content, context } = body;
+  // Validate at runtime — body comes from user input and may not match the type.
+  const { atLine, position, content, context } = body as unknown as Record<
+    string,
+    unknown
+  >;
 
   if (
     typeof atLine !== 'number' ||
-    typeof position !== 'string' ||
-    typeof content !== 'string'
+    typeof content !== 'string' ||
+    (position !== 'before' && position !== 'after')
   ) {
-    return reply
-      .code(400)
-      .send({ error: 'insert-block requires atLine, position, and content' });
+    return reply.code(400).send({
+      error:
+        'insert-block requires atLine, content, and position (before|after)',
+    });
   }
   let fileContent: string;
   try {

--- a/packages/service/src/services/markdown.ts
+++ b/packages/service/src/services/markdown.ts
@@ -192,11 +192,10 @@ export function parseMarkdown(
     const sourceEnd = token.attrGet('data-source-end') || sourceStart;
     if (!sourceStart) return token.content;
 
-    const end = sourceEnd ?? sourceStart;
-    const attrs = ` data-source-start="${sourceStart}" data-source-end="${end}"`;
-    // Inject into the first opening HTML tag
+    const attrs = ` data-source-start="${sourceStart}" data-source-end="${sourceEnd}"`;
+    // Inject into the first opening HTML tag (allow leading whitespace)
     const injected = token.content.replace(
-      /^(<[a-zA-Z][^\s/>]*)/,
+      /^(\s*<[a-zA-Z][^\s/>]*)/,
       `$1${attrs}`,
     );
     // If injection succeeded (content changed), use it; otherwise wrap as fallback

--- a/packages/service/src/services/markdown.ts
+++ b/packages/service/src/services/markdown.ts
@@ -182,6 +182,28 @@ export function parseMarkdown(
     return `<pre${sourceAttrs}><code${langClass}>${escaped}</code></pre>\n`;
   };
 
+  // Custom html_block renderer to preserve source mapping.
+  // markdown-it's default html_block renderer emits token.content verbatim,
+  // ignoring attrs set by the source_map core rule. Inject attributes into the
+  // first HTML tag to avoid an extra wrapper <div> that could break CSS selectors.
+  md.renderer.rules.html_block = (tokens, idx) => {
+    const token = tokens[idx];
+    const sourceStart = token.attrGet('data-source-start');
+    const sourceEnd = token.attrGet('data-source-end') || sourceStart;
+    if (!sourceStart) return token.content;
+
+    const end = sourceEnd ?? sourceStart;
+    const attrs = ` data-source-start="${sourceStart}" data-source-end="${end}"`;
+    // Inject into the first opening HTML tag
+    const injected = token.content.replace(
+      /^(<[a-zA-Z][^\s/>]*)/,
+      `$1${attrs}`,
+    );
+    // If injection succeeded (content changed), use it; otherwise wrap as fallback
+    if (injected !== token.content) return injected;
+    return `<div${attrs}>${token.content}</div>\n`;
+  };
+
   // Custom image renderer for src rewriting
   if (options.basePath) {
     const base = options.basePath;


### PR DESCRIPTION
Closes #168

When editing a block with a lot of content, the CodeMirror editor extends below the popup boundary, hiding the Cancel/Esc controls and bottom content.

**Root cause:** CSS flex children default to min-height: auto, preventing them from shrinking below their content size — even inside a container with max-h-[80vh].

**Changes:**
- BlockEditPopup.tsx: Replace min-h-[200px] with min-h-0 on the CodeEditor flex wrapper so it respects the popup's max-height constraint
- CodeEditor.tsx: Add min-h-0 to the editor container div for the same reason
- Cell edit textarea: Add max-h-[60vh] overflow-y-auto to prevent the same overflow for tall cell content