### PR TITLE
fix: dev server white screen — serve built client under tsx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to jeeves-server
+
+## Prerequisites
+
+- Node.js v24+
+- npm 10+
+- A `jeeves-core` configuration at `J:\config` (or your configured `configRoot`)
+
+## Repository Structure
+
+This is a monorepo with three packages:
+
+```
+packages/
+  service/          # The Fastify server + React SPA client
+    client/         # Vite + React client source
+    src/            # Server TypeScript source
+  jeeves-server/    # Config package (config.json)
+  openclaw/         # OpenClaw plugin (skills, prompt injection)
+```
+
+## Setup
+
+```bash
+git clone https://github.com/karmaniverous/jeeves-server.git
+cd jeeves-server
+npm install
+```
+
+## Development
+
+### Building
+
+From the repo root:
+
+```bash
+npm run build        # Builds server (tsc) + client (Vite) + OpenClaw plugin
+npm run typecheck    # Type-check all packages
+npm run lint         # ESLint
+```
+
+### Running the Dev Server
+
+The server requires `jeeves-core` to be initialized before startup. Use `dev-server.ts` (not `server.ts` directly):
+
+```bash
+# 1. Build the client first (tsx serves built assets, not source)
+npm run build
+
+# 2. Start the dev server
+npx tsx watch packages/service/src/dev-server.ts
+```
+
+The dev server runs on port **19340** (prod uses 1934).
+
+> **Why not `npm run dev`?** The workspace `dev` script runs `server.ts` directly, which requires `jeeves-core` to already be initialized. `dev-server.ts` calls `init()` first, then imports `server.ts`.
+
+> **White screen?** If you see a white screen, the server is likely serving the *source* `client/index.html` (which references `/src/main.tsx`) instead of the built `dist/client/index.html`. Make sure you ran `npm run build` first.
+
+### Client Iteration
+
+There is no standalone Vite dev server. The Fastify server serves the built client assets. For rapid client iteration:
+
+1. Keep the dev server running (`npx tsx watch packages/service/src/dev-server.ts`)
+2. In a second terminal: `npx vite build --watch` (from `packages/service/client/`)
+3. Refresh the browser after each rebuild
+
+### Port Conflicts
+
+If port 19340 is already in use from a previous crashed process:
+
+```powershell
+# Find and kill the process (Windows)
+netstat -aon | findstr :19340
+taskkill /PID <pid> /F
+```
+
+## Dev vs Prod
+
+| | Dev | Prod |
+|---|---|---|
+| **Port** | 19340 | 1934 |
+| **Entry** | `npx tsx watch packages/service/src/dev-server.ts` | NSSM service (global npm install) |
+| **Config** | `packages/jeeves-server/config.json` | Global install `config.json` |
+| **Client** | Built via `npm run build` | Built during `npm publish` |
+
+**Never copy config between dev and prod.** Each has its own OAuth credentials, session secrets, and key seeds.
+
+## Branch Naming
+
+Enforced by lefthook pre-commit hook:
+
+- `bugfix/<name>`
+- `feature/<name>`
+- `chore/<name>`
+- `docs/<name>`
+- `hotfix/<name>`
+- `release/<semver>`
+
+## Commit & PR Guidelines
+
+- Conventional commits: `fix:`, `feat:`, `chore:`, `docs:`, etc.
+- Include the issue number: `fix: description (#123)`
+- Run `npm run typecheck` and `npm run lint` before pushing
+- PRs target `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - Node.js v24+
 - npm 10+
-- A `jeeves-core` configuration at `J:\config` (or your configured `configRoot`)
+- A `jeeves-core` configuration directory (set via `JEEVES_CONFIG_ROOT` env var, defaults to `J:\config` on the reference install)
 
 ## Repository Structure
 
@@ -29,6 +29,15 @@ npm install
 
 ## Development
 
+### Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `JEEVES_WORKSPACE_PATH` | Path to jeeves workspace | `J:\jeeves` |
+| `JEEVES_CONFIG_ROOT` | Path to jeeves-core config | `J:\config` |
+
+Set these before running the dev server if your paths differ from the defaults.
+
 ### Building
 
 From the repo root:
@@ -44,7 +53,7 @@ npm run lint         # ESLint
 The server requires `jeeves-core` to be initialized before startup. Use `dev-server.ts` (not `server.ts` directly):
 
 ```bash
-# 1. Build the client first (tsx serves built assets, not source)
+# 1. Build the client first (the dev server serves built Vite assets, not source)
 npm run build
 
 # 2. Start the dev server
@@ -55,7 +64,7 @@ The dev server runs on port **19340** (prod uses 1934).
 
 > **Why not `npm run dev`?** The workspace `dev` script runs `server.ts` directly, which requires `jeeves-core` to already be initialized. `dev-server.ts` calls `init()` first, then imports `server.ts`.
 
-> **White screen?** If you see a white screen, the server is likely serving the *source* `client/index.html` (which references `/src/main.tsx`) instead of the built `dist/client/index.html`. Make sure you ran `npm run build` first.
+> **White screen?** If you see a white screen, the client assets are probably not built. Run `npm run build` and restart.
 
 ### Client Iteration
 
@@ -69,10 +78,14 @@ There is no standalone Vite dev server. The Fastify server serves the built clie
 
 If port 19340 is already in use from a previous crashed process:
 
-```powershell
-# Find and kill the process (Windows)
+```bash
+# Windows
 netstat -aon | findstr :19340
 taskkill /PID <pid> /F
+
+# macOS / Linux
+lsof -i :19340
+kill -9 <pid>
 ```
 
 ## Dev vs Prod

--- a/packages/service/src/dev-server.ts
+++ b/packages/service/src/dev-server.ts
@@ -1,0 +1,12 @@
+/**
+ * Dev server launcher — initializes jeeves-core before starting the server.
+ * Use this instead of server.ts directly when running `npm run dev`.
+ */
+import { init } from '@karmaniverous/jeeves';
+
+init({
+  workspacePath: 'J:\\jeeves',
+  configRoot: 'J:\\config',
+});
+
+await import('./server.js');

--- a/packages/service/src/dev-server.ts
+++ b/packages/service/src/dev-server.ts
@@ -5,8 +5,8 @@
 import { init } from '@karmaniverous/jeeves';
 
 init({
-  workspacePath: 'J:\\jeeves',
-  configRoot: 'J:\\config',
+  workspacePath: process.env.JEEVES_WORKSPACE_PATH || 'J:\\jeeves',
+  configRoot: process.env.JEEVES_CONFIG_ROOT || 'J:\\config',
 });
 
 await import('./server.js');

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -56,7 +56,18 @@ async function start() {
     await fastify.register(pathRoute);
 
     // Serve React SPA (if built)
-    const clientDir = path.join(__dirname, '..', 'client');
+    // Under tsx (dev), __dirname is src/ so ../client hits the SOURCE client dir
+    // (with unbuilt index.html referencing /src/main.tsx). Detect this and use
+    // the Vite-built dist/client/ instead.
+    let clientDir = path.join(__dirname, '..', 'client');
+    const builtIndex = path.join(clientDir, 'index.html');
+    if (fs.existsSync(builtIndex) && fs.readFileSync(builtIndex, 'utf8').includes('/src/main.tsx')) {
+      // Source client dir — look for built client in dist/client/
+      const distClient = path.join(__dirname, '..', 'dist', 'client');
+      if (fs.existsSync(path.join(distClient, 'index.html'))) {
+        clientDir = distClient;
+      }
+    }
     if (fs.existsSync(clientDir)) {
       await fastify.register(fastifyStatic, {
         root: clientDir,

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -56,18 +56,13 @@ async function start() {
     await fastify.register(pathRoute);
 
     // Serve React SPA (if built)
-    // Under tsx (dev), __dirname is src/ so ../client hits the SOURCE client dir
-    // (with unbuilt index.html referencing /src/main.tsx). Detect this and use
-    // the Vite-built dist/client/ instead.
-    let clientDir = path.join(__dirname, '..', 'client');
-    const builtIndex = path.join(clientDir, 'index.html');
-    if (fs.existsSync(builtIndex) && fs.readFileSync(builtIndex, 'utf8').includes('/src/main.tsx')) {
-      // Source client dir — look for built client in dist/client/
-      const distClient = path.join(__dirname, '..', 'dist', 'client');
-      if (fs.existsSync(path.join(distClient, 'index.html'))) {
-        clientDir = distClient;
-      }
-    }
+    // When running from source (tsx), __dirname ends with /src so ../client
+    // resolves to the source client dir (unbuilt). Detect this and use the
+    // Vite-built dist/client/ instead.
+    const isSourceDir = __dirname.replace(/\\/g, '/').endsWith('/src');
+    let clientDir = isSourceDir
+      ? path.join(__dirname, '..', 'dist', 'client')
+      : path.join(__dirname, '..', 'client');
     if (fs.existsSync(clientDir)) {
       await fastify.register(fastifyStatic, {
         root: clientDir,

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -56,10 +56,12 @@ async function start() {
     await fastify.register(pathRoute);
 
     // Serve React SPA (if built)
-    // When running from source (tsx), __dirname ends with /src so ../client
-    // resolves to the source client dir (unbuilt). Detect this and use the
-    // Vite-built dist/client/ instead.
-    const isSourceDir = __dirname.replace(/\\/g, '/').endsWith('/src');
+    // When running from source (tsx), __dirname is packages/service/src — the
+    // sibling client/ dir has unbuilt source. When running from the tsc build,
+    // __dirname is .../dist/src — the sibling ../client is the built output.
+    // Detect source mode: __dirname ends with /src but does NOT contain /dist/.
+    const normalDir = __dirname.replace(/\\/g, '/');
+    const isSourceDir = normalDir.endsWith('/src') && !normalDir.includes('/dist/');
     let clientDir = isSourceDir
       ? path.join(__dirname, '..', 'dist', 'client')
       : path.join(__dirname, '..', 'client');


### PR DESCRIPTION
Closes #170

**Problem:** When running the dev server via 	sx watch, __dirname resolves to packages/service/src/, so path.join(__dirname, '..', 'client') hits the *source* client/ directory. That directory's index.html references /src/main.tsx — but there's no Vite dev server to handle the .tsx import, resulting in a white screen.

**Fix:** server.ts now detects when it's about to serve the source index.html (by checking for /src/main.tsx in the file) and redirects to dist/client/ when available.

**Also includes:**
- dev-server.ts — launcher that initializes jeeves-core before importing server.ts (required for dev mode)
- CONTRIBUTING.md — developer setup guide covering build, dev server startup, port conflicts, and the dev/prod split