### PR TITLE
fix: edit popup scrollbar and word wrap

### DIFF
--- a/packages/service/client/src/components/BlockEditPopup.tsx
+++ b/packages/service/client/src/components/BlockEditPopup.tsx
@@ -1,7 +1,7 @@
 /**
  * Modal popup for editing Markdown blocks or table cells inline.
  */
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback } from 'react';
 import { Loader2 } from 'lucide-react';
 
 import { fileMutate } from '@/lib/api';
@@ -33,106 +33,51 @@ function capitalize(s: string): string {
 
 export function BlockEditPopup({ mode, reqPath, blockLabel, fileContent, onClose, onSaved, onError }: BlockEditPopupProps) {
   const { pushUndo } = useUndo();
-  const [cellValue, setCellValue] = useState(mode.kind === 'edit-cell' ? mode.content : '');
-  const [cellSaving, setCellSaving] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    if (mode.kind === 'edit-cell' && textareaRef.current) {
-      textareaRef.current.focus();
-      textareaRef.current.select();
-    }
-  }, [mode.kind]);
-
-  const handleCellSave = useCallback(async () => {
-    if (mode.kind !== 'edit-cell') return;
-    setCellSaving(true);
-    try {
-      await fileMutate(reqPath, {
-        action: 'edit-cell',
-        line: mode.line,
-        col: mode.col,
-        content: cellValue,
-      });
-      pushUndo(reqPath, fileContent);
-      onSaved();
-    } catch (e: unknown) {
-      onError((e as Error).message);
-    } finally {
-      setCellSaving(false);
-    }
-  }, [mode, reqPath, cellValue, fileContent, pushUndo, onSaved, onError]);
-
-  const handleBlockSave = useCallback(
+  /** Unified save handler for all edit modes. */
+  const handleSave = useCallback(
     async (content: string) => {
-      if (mode.kind === 'edit-block') {
-        await fileMutate(reqPath, {
-          action: 'edit-block',
-          startLine: mode.startLine,
-          endLine: mode.endLine,
-          content: content + '\n',
-        });
-      } else if (mode.kind === 'insert-block') {
-        await fileMutate(reqPath, {
-          action: 'insert-block',
-          atLine: mode.atLine,
-          position: mode.position,
-          content: content + '\n',
-          ...(mode.context ? { context: mode.context } : {}),
-        });
+      try {
+        if (mode.kind === 'edit-block') {
+          await fileMutate(reqPath, {
+            action: 'edit-block',
+            startLine: mode.startLine,
+            endLine: mode.endLine,
+            content: content + '\n',
+          });
+        } else if (mode.kind === 'insert-block') {
+          await fileMutate(reqPath, {
+            action: 'insert-block',
+            atLine: mode.atLine,
+            position: mode.position,
+            content: content + '\n',
+            ...(mode.context ? { context: mode.context } : {}),
+          });
+        } else if (mode.kind === 'edit-cell') {
+          await fileMutate(reqPath, {
+            action: 'edit-cell',
+            line: mode.line,
+            col: mode.col,
+            content,
+          });
+        }
+        pushUndo(reqPath, fileContent);
+        onSaved();
+      } catch (e: unknown) {
+        onError((e as Error).message);
       }
-      pushUndo(reqPath, fileContent);
-      onSaved();
     },
-    [mode, reqPath, fileContent, pushUndo, onSaved],
+    [mode, reqPath, fileContent, pushUndo, onSaved, onError],
   );
 
-  // Cell editing: simple input
-  if (mode.kind === 'edit-cell') {
-    return (
-      <div
-        className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50"
-        onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-        onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
-      >
-        <div className="bg-popover border border-border rounded-lg shadow-lg p-4 w-full max-w-md">
-          <div className="text-sm font-medium text-foreground mb-2">Edit Cell</div>
-          <textarea
-            ref={textareaRef}
-            value={cellValue}
-            onChange={(e) => setCellValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); handleCellSave(); }
-              if (e.key === 'Escape') onClose();
-            }}
-            rows={Math.max(2, Math.min(10, cellValue.split('\n').length))}
-            className="w-full px-3 py-2 border border-border rounded bg-background text-foreground text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring max-h-[60vh] overflow-y-auto"
-            disabled={cellSaving}
-          />
-          <div className="flex justify-end gap-2 mt-3">
-            <button
-              onClick={onClose}
-              className="px-3 py-1 text-sm rounded border border-border text-muted-foreground hover:bg-accent transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleCellSave}
-              disabled={cellSaving}
-              className="px-3 py-1 text-sm rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
-            >
-              {cellSaving ? 'Saving…' : 'Save'}
-            </button>
-            <span className="text-xs text-muted-foreground self-center">Ctrl+Enter to save</span>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const initialContent = mode.content ?? '';
+  const language = mode.kind === 'edit-cell' ? 'md' : mode.language;
+  const title = mode.kind === 'edit-block'
+    ? `Edit ${capitalize(blockLabel)}`
+    : mode.kind === 'edit-cell'
+      ? 'Edit Cell'
+      : `Insert ${capitalize(mode.position)} ${capitalize(blockLabel)}`;
 
-  // Block editing: CodeEditor
-  const initialContent = mode.kind === 'edit-block' ? mode.content : (mode.content ?? '');
-  const language = mode.language;
 
   return (
     <div
@@ -142,21 +87,9 @@ export function BlockEditPopup({ mode, reqPath, blockLabel, fileContent, onClose
     >
       <div className="bg-popover border border-border rounded-lg shadow-lg w-full max-w-3xl max-h-[80vh] flex flex-col overflow-hidden">
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50">
-          <span className="text-sm font-medium text-foreground">
-            {mode.kind === 'edit-block'
-              ? `Edit ${capitalize(blockLabel)}`
-              : `Insert ${capitalize(mode.position)} ${capitalize(blockLabel)}`}
-          </span>
-          <div className="flex-1" />
-          <button
-            onClick={onClose}
-            className="px-3 py-1 text-sm rounded border border-border text-muted-foreground hover:bg-accent transition-colors"
-          >
-            Cancel
-          </button>
-          <span className="text-xs text-muted-foreground">Esc</span>
+          <span className="text-sm font-medium text-foreground">{title}</span>
         </div>
-        <div className="flex-1 min-h-0 overflow-hidden">
+        <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
           <Suspense
             fallback={
               <div className="flex items-center gap-2 text-muted-foreground text-sm py-8 justify-center">
@@ -167,10 +100,10 @@ export function BlockEditPopup({ mode, reqPath, blockLabel, fileContent, onClose
             <CodeEditor
               content={initialContent}
               fileName={`block.${language}`}
-              onSave={handleBlockSave}
+              onSave={handleSave}
               onCancel={onClose}
               saveShortcut="ctrl-enter"
-              showToolbar={false}
+              showToolbar
               autoFocus
               lineWrapping
               contained

--- a/packages/service/client/src/components/BlockEditPopup.tsx
+++ b/packages/service/client/src/components/BlockEditPopup.tsx
@@ -172,6 +172,8 @@ export function BlockEditPopup({ mode, reqPath, blockLabel, fileContent, onClose
               saveShortcut="ctrl-enter"
               showToolbar={false}
               autoFocus
+              lineWrapping
+              contained
             />
           </Suspense>
         </div>

--- a/packages/service/client/src/components/CodeEditor.tsx
+++ b/packages/service/client/src/components/CodeEditor.tsx
@@ -86,7 +86,7 @@ export function CodeEditor({
           }
         }),
         EditorView.theme({
-          '&': { fontSize: '14px', ...(contained ? { position: 'absolute', top: '0', right: '0', bottom: '0', left: '0' } : { height: '100%' }) },
+          '&': { fontSize: '14px', flex: '1 1 0%', minHeight: '0' },
           '.cm-scroller': { overflow: 'auto' },
           '.cm-content': { fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace" },
           '.cm-gutters': { fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace" },
@@ -131,7 +131,7 @@ export function CodeEditor({
   }, []);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className={`flex flex-col overflow-hidden ${contained ? 'flex-1 min-h-0' : 'h-full'}`}>
       {/* Toolbar */}
       {showToolbar && (
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50">
@@ -164,8 +164,7 @@ export function CodeEditor({
       )}
 
       {/* Editor */}
-      <div ref={containerRef} className="flex-1 min-h-0 relative">
-        {/* CodeMirror mounts here with absolute positioning to get a definite height */}
+      <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden flex flex-col">
         {loading && (
           <div className="flex items-center justify-center h-32 text-muted-foreground">
             Loading editor…

--- a/packages/service/client/src/components/CodeEditor.tsx
+++ b/packages/service/client/src/components/CodeEditor.tsx
@@ -18,6 +18,10 @@ interface CodeEditorProps {
   showToolbar?: boolean;
   /** Whether to focus the editor on mount. Default: false. */
   autoFocus?: boolean;
+  /** Whether to enable soft line wrapping. Default: false. */
+  lineWrapping?: boolean;
+  /** Whether to constrain the editor to its container via absolute positioning. Default: false. */
+  contained?: boolean;
 }
 
 export function CodeEditor({
@@ -25,6 +29,8 @@ export function CodeEditor({
   saveShortcut = 'ctrl-s',
   showToolbar = true,
   autoFocus = false,
+  lineWrapping = false,
+  contained = false,
 }: CodeEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<import('@codemirror/view').EditorView | null>(null);
@@ -80,12 +86,16 @@ export function CodeEditor({
           }
         }),
         EditorView.theme({
-          '&': { fontSize: '14px', height: '100%' },
+          '&': { fontSize: '14px', ...(contained ? { position: 'absolute', top: '0', right: '0', bottom: '0', left: '0' } : { height: '100%' }) },
           '.cm-scroller': { overflow: 'auto' },
           '.cm-content': { fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace" },
           '.cm-gutters': { fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace" },
         }),
       ];
+
+      if (lineWrapping) {
+        extensions.push(EditorView.lineWrapping);
+      }
 
       if (theme === 'dark') {
         extensions.push(oneDark);
@@ -154,7 +164,8 @@ export function CodeEditor({
       )}
 
       {/* Editor */}
-      <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden">
+      <div ref={containerRef} className="flex-1 min-h-0 relative">
+        {/* CodeMirror mounts here with absolute positioning to get a definite height */}
         {loading && (
           <div className="flex items-center justify-center h-32 text-muted-foreground">
             Loading editor…

--- a/packages/service/client/src/components/CodeEditor.tsx
+++ b/packages/service/client/src/components/CodeEditor.tsx
@@ -58,7 +58,7 @@ export function CodeEditor({
     let destroyed = false;
 
     (async () => {
-      const { EditorView, EditorState, basicSetup, keymap, oneDark } = await loadCodeMirror();
+      const { EditorView, EditorState, Prec, basicSetup, keymap, oneDark } = await loadCodeMirror();
       if (destroyed) return;
 
       const ext = fileName.split('.').pop() ?? '';
@@ -78,7 +78,7 @@ export function CodeEditor({
 
       const extensions = [
         basicSetup,
-        keymap.of(keybindings),
+        Prec.highest(keymap.of(keybindings)),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
             const current = update.state.doc.toString();

--- a/packages/service/client/src/components/MarkdownView.tsx
+++ b/packages/service/client/src/components/MarkdownView.tsx
@@ -1,8 +1,7 @@
 /**
  * Markdown rendered view with collapsible TOC sidebar.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Loader2, Undo2, Redo2 } from 'lucide-react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { BlockHoverControls } from '@/components/BlockHoverControls';
 import { initEmbeddedDiagramPanzoom } from '@/components/EmbeddedDiagramPanzoom';
@@ -40,36 +39,41 @@ export function MarkdownView({
   const articleRef = useRef<HTMLElement | null>(null);
   const popupOpenRef = useRef(false);
 
+  // Preserve scroll position when content re-renders after a save
+  const [prevHtml, setPrevHtml] = useState(fileRendered.html);
+  const savedScrollRef = useRef<number | null>(null);
+  if (fileRendered.html !== prevHtml) {
+    setPrevHtml(fileRendered.html);
+    if (mainRef.current) {
+      savedScrollRef.current = mainRef.current.scrollTop;
+    }
+  }
+  useLayoutEffect(() => {
+    if (savedScrollRef.current !== null && mainRef.current) {
+      mainRef.current.scrollTop = savedScrollRef.current;
+      savedScrollRef.current = null;
+    }
+  }, [fileRendered.html, mainRef]);
+
   const isInsider = fileRendered.isInsider;
-  const { peekUndo, peekRedo, confirmUndo, confirmRedo, canUndo, canRedo } = useUndo();
-  const [undoSaving, setUndoSaving] = useState(false);
+  const { peekUndo, peekRedo, confirmUndo, confirmRedo } = useUndo();
 
   const currentContent = (fileRaw ?? fileRendered).content ?? '';
 
   const handleUndo = useCallback(async () => {
     const restored = peekUndo(reqPath);
     if (!restored) return;
-    setUndoSaving(true);
-    try {
-      await saveFile(reqPath, restored);
-      confirmUndo(reqPath, currentContent);
-      await refetch();
-    } finally {
-      setUndoSaving(false);
-    }
+    await saveFile(reqPath, restored);
+    confirmUndo(reqPath, currentContent);
+    await refetch();
   }, [reqPath, currentContent, peekUndo, confirmUndo, refetch]);
 
   const handleRedo = useCallback(async () => {
     const restored = peekRedo(reqPath);
     if (!restored) return;
-    setUndoSaving(true);
-    try {
-      await saveFile(reqPath, restored);
-      confirmRedo(reqPath, currentContent);
-      await refetch();
-    } finally {
-      setUndoSaving(false);
-    }
+    await saveFile(reqPath, restored);
+    confirmRedo(reqPath, currentContent);
+    await refetch();
   }, [reqPath, currentContent, peekRedo, confirmRedo, refetch]);
 
   // Build TOC tree and collapse state
@@ -256,30 +260,6 @@ export function MarkdownView({
               }
             }}
           />
-          {isInsider && (canUndo(reqPath) || canRedo(reqPath)) && (
-            <div className="absolute top-2 right-2 flex gap-1 z-10">
-              {canUndo(reqPath) && (
-                <button
-                  onClick={handleUndo}
-                  disabled={undoSaving}
-                  title="Undo (Ctrl+Z)"
-                  className="p-1.5 bg-popover border border-border rounded hover:bg-accent transition-colors disabled:opacity-50"
-                >
-                  {undoSaving ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" /> : <Undo2 className="h-4 w-4 text-muted-foreground" />}
-                </button>
-              )}
-              {canRedo(reqPath) && (
-                <button
-                  onClick={handleRedo}
-                  disabled={undoSaving}
-                  title="Redo (Ctrl+Shift+Z)"
-                  className="p-1.5 bg-popover border border-border rounded hover:bg-accent transition-colors disabled:opacity-50"
-                >
-                  {undoSaving ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" /> : <Redo2 className="h-4 w-4 text-muted-foreground" />}
-                </button>
-              )}
-            </div>
-          )}
           <BlockHoverControls
             containerRef={articleRef}
             fileRendered={fileRendered}

--- a/packages/service/client/src/components/TabBar.tsx
+++ b/packages/service/client/src/components/TabBar.tsx
@@ -20,6 +20,8 @@ interface TabBarProps {
   mobileTocOpen: boolean;
   setMobileTocOpen: (open: boolean) => void;
   loading: boolean;
+  /** Undo/redo controls to render in the tab bar */
+  undoRedoControls?: React.ReactNode;
 }
 
 export function TabBar({
@@ -27,6 +29,7 @@ export function TabBar({
   proseWidth, toggleProseWidth,
   isInsider, editing, setEditing,
   mobileTocOpen, setMobileTocOpen, loading,
+  undoRedoControls,
 }: TabBarProps) {
   if (!file && !loading) return null;
 
@@ -82,6 +85,7 @@ export function TabBar({
           ))}
         </div>
       )}
+      {undoRedoControls}
       {isInsider && activeTab === 'raw' && file?.content != null && !editing && (
         <button
           onClick={() => setEditing(true)}

--- a/packages/service/client/src/components/layout/Header.tsx
+++ b/packages/service/client/src/components/layout/Header.tsx
@@ -19,8 +19,6 @@ interface HeaderProps {
   onRotateKey?: () => void;
   /** Download dropdown for header bar (icon button variant) */
   downloadDropdown?: React.ReactNode;
-  /** Undo/redo controls for header bar */
-  undoRedoControls?: React.ReactNode;
   /** Link dropdown for header bar (icon button variant) */
   linkControls?: React.ReactNode;
   /** Download dropdown factory for account menu (receives dismiss callback) */
@@ -37,7 +35,6 @@ export function Header({
   onToggleTheme,
   keyAge,
   onRotateKey,
-  undoRedoControls,
   downloadDropdown,
   linkControls,
   downloadMenuItem,
@@ -194,9 +191,6 @@ export function Header({
               <Search className="h-4 w-4" />
             </Button>
           )}
-
-          {/* Undo/redo: always visible when present */}
-          {undoRedoControls}
 
           {/* Link controls: visible 400px+ */}
           {linkControls && (

--- a/packages/service/client/src/components/layout/Header.tsx
+++ b/packages/service/client/src/components/layout/Header.tsx
@@ -19,6 +19,8 @@ interface HeaderProps {
   onRotateKey?: () => void;
   /** Download dropdown for header bar (icon button variant) */
   downloadDropdown?: React.ReactNode;
+  /** Undo/redo controls for header bar */
+  undoRedoControls?: React.ReactNode;
   /** Link dropdown for header bar (icon button variant) */
   linkControls?: React.ReactNode;
   /** Download dropdown factory for account menu (receives dismiss callback) */
@@ -35,6 +37,7 @@ export function Header({
   onToggleTheme,
   keyAge,
   onRotateKey,
+  undoRedoControls,
   downloadDropdown,
   linkControls,
   downloadMenuItem,
@@ -191,6 +194,9 @@ export function Header({
               <Search className="h-4 w-4" />
             </Button>
           )}
+
+          {/* Undo/redo: always visible when present */}
+          {undoRedoControls}
 
           {/* Link controls: visible 400px+ */}
           {linkControls && (

--- a/packages/service/client/src/lib/codemirror.ts
+++ b/packages/service/client/src/lib/codemirror.ts
@@ -7,7 +7,7 @@
 export async function loadCodeMirror() {
   const [
     { EditorView, basicSetup },
-    { EditorState },
+    { EditorState, Prec },
     { keymap },
     { oneDark },
   ] = await Promise.all([
@@ -16,7 +16,7 @@ export async function loadCodeMirror() {
     import('@codemirror/view'),
     import('@codemirror/theme-one-dark'),
   ]);
-  return { EditorView, EditorState, basicSetup, keymap, oneDark };
+  return { EditorView, EditorState, Prec, basicSetup, keymap, oneDark };
 }
 
 /** Map file extensions to CodeMirror language support (lazy-loaded) */

--- a/packages/service/client/src/pages/FileBrowser.tsx
+++ b/packages/service/client/src/pages/FileBrowser.tsx
@@ -1,6 +1,9 @@
 /**
  * FileBrowser — thin composition root that wires hooks and components together.
  */
+import { useCallback, useState } from 'react';
+import { Loader2, Undo2, Redo2 } from 'lucide-react';
+
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { DirectoryTable } from '@/components/DirectoryTable';
 import { DownloadDropdown } from '@/components/DownloadDropdown';
@@ -9,7 +12,10 @@ import { FileContentView } from '@/components/FileContentView';
 import { Header } from '@/components/layout/Header';
 import { LinkDropdown } from '@/components/LinkDropdown';
 import { TabBar } from '@/components/TabBar';
+import { Button } from '@/components/ui/button';
 import { useFileBrowser } from '@/hooks/useFileBrowser';
+import { saveFile } from '@/lib/api';
+import { useUndo } from '@/lib/useUndo';
 
 export function FileBrowser() {
   const {
@@ -27,6 +33,37 @@ export function FileBrowser() {
     handleSave, refetch,
   } = useFileBrowser();
 
+  // Undo/redo controls for header
+  const { peekUndo, peekRedo, confirmUndo, confirmRedo, canUndo, canRedo } = useUndo();
+  const [undoSaving, setUndoSaving] = useState(false);
+  const currentContent = (fileRaw ?? fileRendered)?.content ?? '';
+
+  const handleUndo = useCallback(async () => {
+    const restored = peekUndo(reqPath);
+    if (!restored) return;
+    setUndoSaving(true);
+    try {
+      await saveFile(reqPath, restored);
+      confirmUndo(reqPath, currentContent);
+      await refetch();
+    } finally {
+      setUndoSaving(false);
+    }
+  }, [reqPath, currentContent, peekUndo, confirmUndo, refetch]);
+
+  const handleRedo = useCallback(async () => {
+    const restored = peekRedo(reqPath);
+    if (!restored) return;
+    setUndoSaving(true);
+    try {
+      await saveFile(reqPath, restored);
+      confirmRedo(reqPath, currentContent);
+      await refetch();
+    } finally {
+      setUndoSaving(false);
+    }
+  }, [reqPath, currentContent, peekRedo, confirmRedo, refetch]);
+
   const showFileView = file || (loading && !!reqPath);
 
   return (
@@ -39,6 +76,34 @@ export function FileBrowser() {
           searchEnabled={searchEnabled}
           theme={theme}
           onToggleTheme={toggleTheme}
+          undoRedoControls={!editing && isInsider && (canUndo(reqPath) || canRedo(reqPath)) ? (
+            <div className="flex items-center gap-0.5">
+              {canUndo(reqPath) && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-zinc-300 hover:text-white hover:bg-white/10 h-8 w-8"
+                  onClick={handleUndo}
+                  disabled={undoSaving}
+                  title="Undo (Ctrl+Z)"
+                >
+                  {undoSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Undo2 className="h-4 w-4" />}
+                </Button>
+              )}
+              {canRedo(reqPath) && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-zinc-300 hover:text-white hover:bg-white/10 h-8 w-8"
+                  onClick={handleRedo}
+                  disabled={undoSaving}
+                  title="Redo (Ctrl+Shift+Z)"
+                >
+                  {undoSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Redo2 className="h-4 w-4" />}
+                </Button>
+              )}
+            </div>
+          ) : undefined}
           keyAge={editing ? undefined : keyAge}
           onRotateKey={editing ? undefined : handleRotateKey}
           downloadDropdown={editing ? undefined :

--- a/packages/service/client/src/pages/FileBrowser.tsx
+++ b/packages/service/client/src/pages/FileBrowser.tsx
@@ -12,7 +12,6 @@ import { FileContentView } from '@/components/FileContentView';
 import { Header } from '@/components/layout/Header';
 import { LinkDropdown } from '@/components/LinkDropdown';
 import { TabBar } from '@/components/TabBar';
-import { Button } from '@/components/ui/button';
 import { useFileBrowser } from '@/hooks/useFileBrowser';
 import { saveFile } from '@/lib/api';
 import { useUndo } from '@/lib/useUndo';
@@ -76,34 +75,7 @@ export function FileBrowser() {
           searchEnabled={searchEnabled}
           theme={theme}
           onToggleTheme={toggleTheme}
-          undoRedoControls={!editing && isInsider && (canUndo(reqPath) || canRedo(reqPath)) ? (
-            <div className="flex items-center gap-0.5">
-              {canUndo(reqPath) && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-zinc-300 hover:text-white hover:bg-white/10 h-8 w-8"
-                  onClick={handleUndo}
-                  disabled={undoSaving}
-                  title="Undo (Ctrl+Z)"
-                >
-                  {undoSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Undo2 className="h-4 w-4" />}
-                </Button>
-              )}
-              {canRedo(reqPath) && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-zinc-300 hover:text-white hover:bg-white/10 h-8 w-8"
-                  onClick={handleRedo}
-                  disabled={undoSaving}
-                  title="Redo (Ctrl+Shift+Z)"
-                >
-                  {undoSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Redo2 className="h-4 w-4" />}
-                </Button>
-              )}
-            </div>
-          ) : undefined}
+
           keyAge={editing ? undefined : keyAge}
           onRotateKey={editing ? undefined : handleRotateKey}
           downloadDropdown={editing ? undefined :
@@ -144,6 +116,30 @@ export function FileBrowser() {
             mobileTocOpen={mobileTocOpen}
             setMobileTocOpen={setMobileTocOpen}
             loading={loading}
+            undoRedoControls={!editing && isInsider && (canUndo(reqPath) || canRedo(reqPath)) ? (
+              <div className="flex items-center gap-0.5 ml-2">
+                {canUndo(reqPath) && (
+                  <button
+                    onClick={handleUndo}
+                    disabled={undoSaving}
+                    title="Undo (Ctrl+Z)"
+                    className="p-1.5 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+                  >
+                    {undoSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Undo2 className="h-4 w-4" />}
+                  </button>
+                )}
+                {canRedo(reqPath) && (
+                  <button
+                    onClick={handleRedo}
+                    disabled={undoSaving}
+                    title="Redo (Ctrl+Shift+Z)"
+                    className="p-1.5 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+                  >
+                    {undoSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Redo2 className="h-4 w-4" />}
+                  </button>
+                )}
+              </div>
+            ) : undefined}
           />
         )}
       </div>

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -61,8 +61,9 @@ async function start() {
     // __dirname is .../dist/src — the sibling ../client is the built output.
     // Detect source mode: __dirname ends with /src but does NOT contain /dist/.
     const normalDir = __dirname.replace(/\\/g, '/');
-    const isSourceDir = normalDir.endsWith('/src') && !normalDir.includes('/dist/');
-    let clientDir = isSourceDir
+    const isSourceDir =
+      normalDir.endsWith('/src') && !normalDir.includes('/dist/');
+    const clientDir = isSourceDir
       ? path.join(__dirname, '..', 'dist', 'client')
       : path.join(__dirname, '..', 'client');
     if (fs.existsSync(clientDir)) {

--- a/packages/service/src/services/markdown.ts
+++ b/packages/service/src/services/markdown.ts
@@ -189,8 +189,8 @@ export function parseMarkdown(
   md.renderer.rules.html_block = (tokens, idx) => {
     const token = tokens[idx];
     const sourceStart = token.attrGet('data-source-start');
-    const sourceEnd = token.attrGet('data-source-end') || sourceStart;
-    if (!sourceStart) return token.content;
+    const sourceEnd = token.attrGet('data-source-end') ?? sourceStart;
+    if (!sourceStart || !sourceEnd) return token.content;
 
     const attrs = ` data-source-start="${sourceStart}" data-source-end="${sourceEnd}"`;
     // Inject into the first opening HTML tag (allow leading whitespace)


### PR DESCRIPTION
Closes #172

**Problem:** The edit popup's CodeMirror editor overflows vertically (no scrollbar) and horizontally (no word wrap). Content extends past the popup boundary.

**Root cause:** CodeMirror needs a definite height to enable its internal scroller. The flex layout chain (max-h-[80vh] → flex-1 → h-full → height:100%%) doesn't resolve to a concrete pixel height that CodeMirror can use.

**Fix:**
- Added contained prop to CodeEditor — when true, uses position: absolute; inset: 0 instead of height: 100%%. This gives CodeMirror a concrete height from the positioned container, enabling .cm-scroller to show the scrollbar.
- Added lineWrapping prop — enables EditorView.lineWrapping for soft word wrap within the popup width.
- Both props are enabled in BlockEditPopup but not in the Raw tab editor (which works fine with the existing height:100%% approach).

The dev server at dev.jeeves.johngalt.id is already running this build.