### PR TITLE
fix: resolve serverRoot via package.json discovery (#178)

### DIFF
--- a/packages/service/src/routes/api/sharing.ts
+++ b/packages/service/src/routes/api/sharing.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { FastifyPluginAsync, FastifyReply } from 'fastify';
+import { packageDirectorySync } from 'package-directory';
 
 import { _pathMatchesScopes } from '../../auth/keys.js';
 import { findInsider } from '../../auth/resolve.js';
@@ -27,7 +28,12 @@ import { fsPathToUrl, getRoots } from '../../util/platform.js';
 import { setInsiderKey } from '../../util/state.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const serverRoot = path.resolve(__dirname, '..', '..', '..');
+
+/**
+ * Resolve the package root via `package-directory` rather than fixed `..`
+ * hops, which break when the compiled output adds a `dist/` layer.
+ */
+const serverRoot = packageDirectorySync({ cwd: __dirname }) ?? __dirname;
 
 /** Build a deep-share browse URL from its constituent parts. */
 function buildDeepShareUrl(


### PR DESCRIPTION
## Fix

Resolves #178 — README, privacy, and terms links broken in production build.

### Problem

`sharing.ts` computed `serverRoot` via a fixed number of `../` hops:

```ts
const serverRoot = path.resolve(__dirname, '..', '..', '..');
```

This works in source (`src/routes/api/` → package root in 3 hops) but breaks in the compiled build (`dist/src/routes/api/` → `dist/` in 3 hops, missing the package root by one level).

### Fix

Replace fixed hops with a `findPackageRoot()` utility that walks up from `__dirname` until it finds a directory containing `package.json`. This is robust across source and compiled contexts.

### Verification

- typecheck ✅
- lint ✅  
- build ✅
- test ✅ (309/309, including sharing.test.ts)
