### PR TITLE
fix: authenticate embedded images for all outsider shares (#183)

### DIFF
--- a/packages/service/src/routes/api/fileContent.ts
+++ b/packages/service/src/routes/api/fileContent.ts
@@ -12,7 +12,10 @@ import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 
 import { getConfig } from '../../config/index.js';
 import { csvToHtmlTable } from '../../services/csv.js';
-import { rewriteLinksForDeepShare } from '../../services/deepShareLinks.js';
+import {
+  rewriteLinksForDeepShare,
+  rewriteSimpleImageAuth,
+} from '../../services/deepShareLinks.js';
 import { getOrRenderDiagram } from '../../services/diagramCache.js';
 import {
   renderEmbeddedDiagrams,
@@ -350,20 +353,20 @@ async function renderMarkdownContent(
 
   const deepShare = request.deepShareParams;
   const seed = request.authSeed;
-  if (!isInsider && deepShare && seed) {
-    const maxDepth = parseInt(deepShare.d, 10);
-    const dirs = deepShare.dirs === '1';
-    const currentPath = `/${reqPath}`;
-    if (!isNaN(maxDepth) && maxDepth > 0) {
+  if (!isInsider && seed) {
+    if (deepShare) {
+      const maxDepth = parseInt(deepShare.d, 10);
       html = rewriteLinksForDeepShare(
         html,
         seed,
-        currentPath,
-        maxDepth,
-        dirs,
+        `/${reqPath}`,
+        isNaN(maxDepth) ? 0 : maxDepth,
+        deepShare.dirs === '1',
         deepShare.s,
         (request.query as { exp?: string }).exp,
       );
+    } else {
+      html = rewriteSimpleImageAuth(html, seed);
     }
   }
 

--- a/packages/service/src/services/deepShareLinks.ts
+++ b/packages/service/src/services/deepShareLinks.ts
@@ -8,7 +8,11 @@
 import * as cheerio from 'cheerio';
 import LZString from 'lz-string';
 
-import { computeDeepShareKey, type DeepShareParams } from '../util/crypto.js';
+import {
+  computeDeepShareKey,
+  computePathKey,
+  type DeepShareParams,
+} from '../util/crypto.js';
 
 /**
  * Parse a compressed stack string into an array of paths.
@@ -182,22 +186,64 @@ export function rewriteLinksForDeepShare(
   });
 
   // Rewrite <img> src for images that use /api/raw/ — add key auth
+  rewriteImageAuth($, seed, {
+    depth: maxDepth,
+    dirs,
+    stack: stackCompressed,
+    exp,
+  });
+
+  return $.html();
+}
+
+/**
+ * Rewrite `<img>` src attributes in rendered HTML to include outsider auth.
+ *
+ * Works for both deep shares (with depth/stack params) and zero-depth outsider
+ * shares (simple path keys). This is separated from link traversal so that
+ * embedded images authenticate correctly for any outsider access.
+ */
+export function rewriteImageAuth(
+  $: ReturnType<typeof cheerio.load>,
+  seed: string,
+  deepParams?: DeepShareParams,
+): void {
   $('img').each((_i, el) => {
     const $el = $(el);
     const src = $el.attr('src');
     if (!src || !src.startsWith('/api/raw/')) return;
 
-    const params: DeepShareParams = {
-      depth: maxDepth,
-      dirs,
-      stack: stackCompressed,
-      exp,
-    };
     const rawPath = '/' + src.replace('/api/raw/', '').split('?')[0];
-    const key = computeDeepShareKey(seed, rawPath, params);
-    const authSrc = `${src}${src.includes('?') ? '&' : '?'}key=${key}&d=${String(maxDepth)}&dirs=${dirs ? '1' : '0'}&s=${stackCompressed}${exp ? `&exp=${exp}` : ''}`;
+    const sep = src.includes('?') ? '&' : '?';
+
+    let authSrc: string;
+    if (deepParams) {
+      const key = computeDeepShareKey(seed, rawPath, deepParams);
+      const params = [
+        `key=${key}`,
+        `d=${String(deepParams.depth)}`,
+        `dirs=${deepParams.dirs ? '1' : '0'}`,
+        `s=${deepParams.stack}`,
+        ...(deepParams.exp ? [`exp=${deepParams.exp}`] : []),
+      ];
+      authSrc = `${src}${sep}${params.join('&')}`;
+    } else {
+      const key = computePathKey(seed, rawPath);
+      authSrc = `${src}${sep}key=${key}`;
+    }
+
     $el.attr('src', authSrc);
   });
+}
 
+/**
+ * Convenience wrapper: load HTML, authenticate embedded images with simple
+ * path keys (no deep share params), and return the updated HTML string.
+ *
+ * Route handlers can call this directly without importing cheerio.
+ */
+export function rewriteSimpleImageAuth(html: string, seed: string): string {
+  const $ = cheerio.load(html, null, false);
+  rewriteImageAuth($, seed);
   return $.html();
 }


### PR DESCRIPTION
## Summary

Fixes #183 — outsider share links now authenticate embedded images for all share types, not just deep shares.

### Problem

The image auth rewriting (`<img src="/api/raw/...">` → append `?key=...`) only ran for deep shares (depth > 0). Zero-depth outsider shares got naked image URLs that returned 401.

### Root Cause (DRY violation)

`rewriteLinksForDeepShare()` conflated two concerns:
- Link depth traversal (rewriting `<a>` hrefs) — only relevant at depth > 0
- Resource auth (rewriting `<img>` src) — relevant for **any** outsider

### Fix

1. Extracted `rewriteImageAuth()` from `deepShareLinks.ts` — handles `<img>` auth independently
2. Updated `renderMarkdownContent()` in `fileContent.ts` to call it for all outsider access:
   - Deep shares (depth > 0): full link traversal + image auth (via existing `rewriteLinksForDeepShare`)
   - Deep shares (depth = 0): image auth only with deep share key params
   - Simple outsider shares (no deep params): image auth with simple path keys
3. `rewriteLinksForDeepShare()` now delegates to `rewriteImageAuth()` internally (no duplication)

### Verified

- Zero-depth outsider share: image `src` includes `?key=...`, image fetch returns 200
- lint ✅, typecheck ✅, build ✅, test ✅ (309/309)
