### PR TITLE
fix: resolve state.json from state root instead of package directory (#185)

### DIFF
--- a/packages/service/src/config/loadConfig.test.ts
+++ b/packages/service/src/config/loadConfig.test.ts
@@ -4,6 +4,13 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@karmaniverous/jeeves', () => ({
+  getConfigRoot: () => loadConfigTestConfigRoot,
+  SERVER_PORT: 1934,
+}));
+
+let loadConfigTestConfigRoot = '';
+
 import { clearConfig, getConfig, initConfig, loadConfig } from './index.js';
 
 const VALID_CONFIG = {
@@ -28,6 +35,8 @@ describe('loadConfig', () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-config-'));
+    loadConfigTestConfigRoot = path.join(tmpDir, 'config');
+    fs.mkdirSync(loadConfigTestConfigRoot, { recursive: true });
     clearConfig();
   });
 
@@ -159,6 +168,8 @@ describe('deprecated config property migration', () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-config-'));
+    loadConfigTestConfigRoot = path.join(tmpDir, 'config');
+    fs.mkdirSync(loadConfigTestConfigRoot, { recursive: true });
     clearConfig();
   });
 
@@ -235,6 +246,8 @@ describe('config singleton', () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-config-'));
+    loadConfigTestConfigRoot = path.join(tmpDir, 'config');
+    fs.mkdirSync(loadConfigTestConfigRoot, { recursive: true });
     clearConfig();
   });
 

--- a/packages/service/src/config/resolve.test.ts
+++ b/packages/service/src/config/resolve.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildRuntimeConfig,
@@ -232,7 +232,27 @@ describe('deriveInternalKey', () => {
   });
 });
 
+vi.mock('@karmaniverous/jeeves', () => ({
+  getConfigRoot: () => buildRuntimeConfigTestConfigRoot,
+  SERVER_PORT: 1934,
+}));
+
+let buildRuntimeConfigTestConfigRoot = '';
+
 describe('buildRuntimeConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-brc-'));
+    buildRuntimeConfigTestConfigRoot = path.join(tmpDir, 'config');
+    fs.mkdirSync(buildRuntimeConfigTestConfigRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
   it('constructs correct path fields', () => {
     const config = {
       port: 1934,
@@ -253,12 +273,48 @@ describe('buildRuntimeConfig', () => {
       '/srv/jeeves',
       '/srv/jeeves/config.json',
     );
-    expect(result.stateFile).toBe(path.join('/srv/jeeves', 'state.json'));
+
+    const expectedStateDir = path.join(tmpDir, 'state', 'jeeves-server');
+    expect(result.stateFile).toBe(path.join(expectedStateDir, 'state.json'));
+    expect(fs.existsSync(expectedStateDir)).toBe(true);
     expect(result.eventsLog).toBe(
       path.join('/srv/jeeves', 'logs', 'webhook-events.jsonl'),
     );
     expect(result.configPath).toBe('/srv/jeeves/config.json');
     expect(result.port).toBe(1934);
     expect(result.authModes).toEqual(['keys']);
+  });
+
+  it('migrates state.json from old location', () => {
+    const config = {
+      port: 1934,
+      eventTimeoutMs: 30000,
+      eventLogPurgeMs: 2592000000,
+      maxZipSizeMb: 100,
+      chromePath: '/usr/bin/chrome',
+      scopes: {},
+      events: {},
+      auth: { modes: ['keys' as const] },
+      keys: { primary: 'a'.repeat(64) },
+      insiders: {},
+      go: {},
+    } as JeevesConfig;
+
+    const oldRootDir = path.join(tmpDir, 'pkg');
+    fs.mkdirSync(oldRootDir, { recursive: true });
+    const oldState = {
+      insiderKeys: { 'a@b.com': { seed: 'old', createdAt: '2026-01-01' } },
+    };
+    fs.writeFileSync(
+      path.join(oldRootDir, 'state.json'),
+      JSON.stringify(oldState),
+    );
+
+    const result = buildRuntimeConfig(config, oldRootDir, '/cfg.json');
+
+    const newState = JSON.parse(
+      fs.readFileSync(result.stateFile, 'utf8'),
+    ) as unknown;
+    expect(newState).toEqual(oldState);
   });
 });

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -232,7 +232,9 @@ export function buildRuntimeConfig(
 ): RuntimeConfig {
   const configRoot = getConfigRoot();
   const stateDir = path.join(
-    configRoot.replace(/[\\/]config$/, path.sep + 'state'),
+    path.basename(configRoot) === 'config'
+      ? path.join(path.dirname(configRoot), 'state')
+      : configRoot,
     'jeeves-server',
   );
   fs.mkdirSync(stateDir, { recursive: true });

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -8,6 +8,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { getConfigRoot } from '@karmaniverous/jeeves';
+
 import { computeInsiderKey } from '../util/crypto.js';
 import type { JeevesConfig } from './schema.js';
 import { isScopeName } from './schema.js';
@@ -228,7 +230,19 @@ export function buildRuntimeConfig(
   rootDir: string,
   configPath: string,
 ): RuntimeConfig {
-  const stateFile = path.join(rootDir, 'state.json');
+  const configRoot = getConfigRoot();
+  const stateDir = path.join(
+    configRoot.replace(/[\\/]config$/, path.sep + 'state'),
+    'jeeves-server',
+  );
+  fs.mkdirSync(stateDir, { recursive: true });
+  const stateFile = path.join(stateDir, 'state.json');
+
+  // Migrate state.json from old location (package root) if needed
+  const oldStateFile = path.join(rootDir, 'state.json');
+  if (fs.existsSync(oldStateFile) && !fs.existsSync(stateFile)) {
+    fs.copyFileSync(oldStateFile, stateFile);
+  }
 
   const resolvedKeys = resolveKeys(
     config.keys as Record<


### PR DESCRIPTION
Fixes #185. Moves state.json from the npm package directory to the Jeeves state root (J:\state\jeeves-server\) so insider seeds survive npm upgrades. Includes migration: copies existing state.json from old location on first run.