### PR TITLE
fix: store insider seeds in config.json instead of state.json (#185)

### DIFF
--- a/packages/service/src/config/resolve.test.ts
+++ b/packages/service/src/config/resolve.test.ts
@@ -143,6 +143,45 @@ describe('resolveInsiders', () => {
     expect(result[0].seed).toBe('');
     expect(result[0].keyCreatedAt).toBe(null);
   });
+
+  it('prefers config seed over state seed', () => {
+    const stateFile = path.join(tmpDir, 'state.json');
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({
+        insiderKeys: {
+          'test@example.com': { seed: 'stateseed', createdAt: '2026-01-01' },
+        },
+      }),
+    );
+    const result = resolveInsiders(
+      {
+        'test@example.com': {
+          seed: 'configseed',
+          keyCreatedAt: '2026-02-01',
+        },
+      },
+      {},
+      stateFile,
+    );
+    expect(result[0].seed).toBe('configseed');
+    expect(result[0].keyCreatedAt).toBe('2026-02-01');
+  });
+
+  it('falls back to state seed when config seed is absent', () => {
+    const stateFile = path.join(tmpDir, 'state.json');
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({
+        insiderKeys: {
+          'test@example.com': { seed: 'stateseed', createdAt: '2026-01-01' },
+        },
+      }),
+    );
+    const result = resolveInsiders({ 'test@example.com': {} }, {}, stateFile);
+    expect(result[0].seed).toBe('stateseed');
+    expect(result[0].keyCreatedAt).toBe('2026-01-01');
+  });
 });
 
 describe('resolveNamedScopes', () => {

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -143,12 +143,19 @@ export function resolveKeys(
 }
 
 /**
- * Resolve insider entries by merging config (identity + scopes) with state (keys).
+ * Resolve insider entries by reading seed from config first, falling back to
+ * state.json for migration from older versions.
  */
 export function resolveInsiders(
   insiders: Record<
     string,
-    { scopes?: unknown; allow?: string[]; deny?: string[] }
+    {
+      scopes?: unknown;
+      allow?: string[];
+      deny?: string[];
+      seed?: string;
+      keyCreatedAt?: string;
+    }
   >,
   namedScopes: Record<string, { allow?: string[]; deny?: string[] }>,
   stateFile: string,
@@ -170,13 +177,11 @@ export function resolveInsiders(
       allow: entry.allow,
       deny: entry.deny,
     });
+    // Prefer seed from config.json; fall back to state.json for migration
     const stateKey = serverState.insiderKeys?.[email];
-    return {
-      email,
-      seed: stateKey?.seed ?? '',
-      scopes,
-      keyCreatedAt: stateKey?.createdAt ?? null,
-    };
+    const seed = entry.seed ?? stateKey?.seed ?? '';
+    const keyCreatedAt = entry.keyCreatedAt ?? stateKey?.createdAt ?? null;
+    return { email, seed, scopes, keyCreatedAt };
   });
 }
 
@@ -239,10 +244,7 @@ export function buildRuntimeConfig(
     config.scopes as Record<string, { allow?: string[]; deny?: string[] }>,
   );
   const resolvedInsiders = resolveInsiders(
-    config.insiders as Record<
-      string,
-      { scopes?: unknown; allow?: string[]; deny?: string[] }
-    >,
+    config.insiders,
     config.scopes as Record<string, { allow?: string[]; deny?: string[] }>,
     stateFile,
   );

--- a/packages/service/src/config/schema.ts
+++ b/packages/service/src/config/schema.ts
@@ -63,13 +63,17 @@ export const scopesSchema = z.union([
   scopesObjectSchema,
 ]);
 
-/** Insider entry (identity + scopes only; keys are in state.json) */
+/** Insider entry (identity + scopes + optional persisted seed) */
 export const insiderEntrySchema = z.object({
   scopes: scopesSchema.optional(),
   /** Extra allow patterns merged on top of named scope references */
   allow: z.array(z.string()).optional(),
   /** Extra deny patterns merged on top of named scope references */
   deny: z.array(z.string()).optional(),
+  /** Auto-generated insider seed, persisted in config.json */
+  seed: z.string().min(1).optional(),
+  /** ISO timestamp of when the seed was created */
+  keyCreatedAt: z.string().optional(),
 });
 
 /** Key entry â€" plain string (seed, no scopes) or object with key + optional scopes */

--- a/packages/service/src/routes/api/sharing.ts
+++ b/packages/service/src/routes/api/sharing.ts
@@ -150,7 +150,7 @@ export const sharingRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   // POST /api/rotate-key
-  fastify.post('/api/rotate-key', (request, reply) => {
+  fastify.post('/api/rotate-key', async (request, reply) => {
     const insiderEmail = request.insiderEmail;
     if (!insiderEmail)
       return reply.code(403).send({ error: 'Insider auth required' });
@@ -161,7 +161,7 @@ export const sharingRoutes: FastifyPluginAsync = async (fastify) => {
 
     const newSeed = crypto.randomBytes(32).toString('hex');
     const now = new Date().toISOString();
-    setInsiderKey(insider.email, newSeed, now);
+    await setInsiderKey(insider.email, newSeed, now);
     resetConfig();
 
     return reply.send({ ok: true, keyCreatedAt: now });

--- a/packages/service/src/routes/auth.ts
+++ b/packages/service/src/routes/auth.ts
@@ -107,7 +107,7 @@ export const authRoute: FastifyPluginAsync = async (fastify) => {
       insider.seed = newSeed;
 
       // Persist to state.json (mutable runtime state)
-      setInsiderKey(insider.email, newSeed, timestamp);
+      await setInsiderKey(insider.email, newSeed, timestamp);
       resetConfig(); // Reload to pick up new state
     }
 

--- a/packages/service/src/routes/keys.ts
+++ b/packages/service/src/routes/keys.ts
@@ -86,7 +86,7 @@ export const keysRoute: FastifyPluginAsync = async (fastify) => {
         const insiderResult = resolveInsiderKeyAuth(config, provided);
         if (insiderResult.valid && insiderResult.email) {
           // Insider key rotation
-          return rotateInsiderSeed(insiderResult.email, config);
+          return await rotateInsiderSeed(insiderResult.email, config);
         }
 
         // Machine key rotation is not supported with TS config
@@ -105,7 +105,7 @@ export const keysRoute: FastifyPluginAsync = async (fastify) => {
       // Try session-based auth
       const sessionResult = resolveSessionAuth(config, request);
       if (sessionResult.valid && sessionResult.email) {
-        return rotateInsiderSeed(sessionResult.email, config);
+        return await rotateInsiderSeed(sessionResult.email, config);
       }
 
       return reply.code(401).send({ error: 'Invalid insider key' });
@@ -149,7 +149,7 @@ export const keysRoute: FastifyPluginAsync = async (fastify) => {
   );
 };
 
-function rotateInsiderSeed(
+async function rotateInsiderSeed(
   email: string,
   config: ReturnType<typeof getConfig>,
 ) {
@@ -159,7 +159,7 @@ function rotateInsiderSeed(
   const rotatedSeed = crypto.randomBytes(32).toString('hex');
   const timestamp = new Date().toISOString();
 
-  setInsiderKey(insider.email, rotatedSeed, timestamp);
+  await setInsiderKey(insider.email, rotatedSeed, timestamp);
   appendEvent({
     kind: 'insider_key_rotated',
     email: insider.email,

--- a/packages/service/src/util/state.ts
+++ b/packages/service/src/util/state.ts
@@ -2,7 +2,11 @@
  * Server state management (key rotation tracking, etc.)
  */
 
+import crypto from 'node:crypto';
 import fs from 'node:fs';
+import path from 'node:path';
+
+import { withFileLock } from '@karmaniverous/jeeves';
 
 import { getConfig } from '../config/index.js';
 import type { ServerState } from '../config/types.js';
@@ -32,6 +36,70 @@ function saveState(state: ServerState): void {
 }
 
 /**
+ * Atomically write JSON to a file (write to tmp, then rename).
+ */
+function atomicWriteJson(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath);
+  const tmpFile = path.join(
+    dir,
+    `.tmp-${crypto.randomBytes(8).toString('hex')}.json`,
+  );
+  fs.writeFileSync(tmpFile, JSON.stringify(data, null, 2), 'utf8');
+  fs.renameSync(tmpFile, filePath);
+}
+
+/**
+ * Persist an insider's seed and keyCreatedAt into the config JSON file.
+ * Preserves all existing content — only updates the specific insider entry.
+ * Uses a file lock to prevent concurrent first-logins from losing updates.
+ */
+async function writeInsiderSeedToConfig(
+  email: string,
+  seed: string,
+  createdAt: string,
+): Promise<void> {
+  const { configPath } = getConfig();
+  const normalizedEmail = email.toLowerCase();
+
+  await withFileLock(configPath, () => {
+    let rawConfig: Record<string, unknown>;
+    try {
+      rawConfig = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Record<
+        string,
+        unknown
+      >;
+    } catch (err) {
+      console.warn('Failed to read config for insider seed update:', err);
+      return;
+    }
+
+    const insiders = (rawConfig.insiders ?? {}) as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    // Find the matching insider key (case-insensitive)
+    const matchingKey = Object.keys(insiders).find(
+      (k) => k.toLowerCase() === normalizedEmail,
+    );
+    if (!matchingKey) return; // Insider not in config — skip
+
+    insiders[matchingKey] = {
+      ...insiders[matchingKey],
+      seed,
+      keyCreatedAt: createdAt,
+    };
+    rawConfig.insiders = insiders;
+
+    try {
+      atomicWriteJson(configPath, rawConfig);
+    } catch (err) {
+      console.warn('Failed to write config for insider seed update:', err);
+    }
+  });
+}
+
+/**
  * Set key rotation timestamp
  */
 export function setKeyRotationTimestamp(timestamp: string): void {
@@ -41,13 +109,18 @@ export function setKeyRotationTimestamp(timestamp: string): void {
 }
 
 /**
- * Set an insider's auto-generated key in state
+ * Set an insider's auto-generated key.
+ * Writes to config.json (primary) and state.json (backward compat).
  */
-export function setInsiderKey(
+export async function setInsiderKey(
   email: string,
   seed: string,
   createdAt: string,
-): void {
+): Promise<void> {
+  // Write to config.json (primary storage)
+  await writeInsiderSeedToConfig(email, seed, createdAt);
+
+  // Write to state.json (backward compat during transition)
   const state = loadState();
   if (!state.insiderKeys) state.insiderKeys = {};
   state.insiderKeys[email.toLowerCase()] = { seed, createdAt };


### PR DESCRIPTION
## Summary

- Insider seeds now stored in `config.json` alongside other keys/secrets, surviving npm upgrades
- `setInsiderKey()` writes seed + keyCreatedAt to config.json (atomic write) and state.json (backward compat)
- `resolveInsiders()` prefers config seed, falls back to state.json for migration from older versions
- Added `seed` and `keyCreatedAt` optional fields to `insiderEntrySchema`

Fixes #185.

## Test plan

- [x] Lint passes with zero errors/warnings
- [x] TypeScript type-check passes
- [x] Build succeeds (server + client)
- [x] All 311 tests pass including 2 new tests for config-seed priority and state-seed fallback
- [ ] Manual: verify first Google login writes seed to config.json
- [ ] Manual: verify npm upgrade preserves insider seeds in config.json
- [ ] Manual: verify existing state.json seeds are picked up as migration fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)