### PR TITLE
fix: remove state.json and dead keyRotatedAt code (#192)

### DIFF
--- a/packages/service/src/config/resolve.test.ts
+++ b/packages/service/src/config/resolve.test.ts
@@ -1,8 +1,6 @@
-import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   buildRuntimeConfig,
@@ -106,54 +104,18 @@ describe('resolveKeys', () => {
 });
 
 describe('resolveInsiders', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-resolve-'));
-  });
-
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
   it('normalizes email to lowercase', () => {
-    const stateFile = path.join(tmpDir, 'state.json');
-    const result = resolveInsiders({ 'Test@Example.COM': {} }, {}, stateFile);
+    const result = resolveInsiders({ 'Test@Example.COM': {} }, {});
     expect(result[0].email).toBe('test@example.com');
   });
 
-  it('merges state keys when available', () => {
-    const stateFile = path.join(tmpDir, 'state.json');
-    fs.writeFileSync(
-      stateFile,
-      JSON.stringify({
-        insiderKeys: {
-          'test@example.com': { seed: 'stateseed', createdAt: '2026-01-01' },
-        },
-      }),
-    );
-    const result = resolveInsiders({ 'test@example.com': {} }, {}, stateFile);
-    expect(result[0].seed).toBe('stateseed');
-    expect(result[0].keyCreatedAt).toBe('2026-01-01');
-  });
-
-  it('returns empty seed when no state exists', () => {
-    const stateFile = path.join(tmpDir, 'state.json');
-    const result = resolveInsiders({ 'new@example.com': {} }, {}, stateFile);
+  it('returns empty seed when no seed is configured', () => {
+    const result = resolveInsiders({ 'new@example.com': {} }, {});
     expect(result[0].seed).toBe('');
     expect(result[0].keyCreatedAt).toBe(null);
   });
 
-  it('prefers config seed over state seed', () => {
-    const stateFile = path.join(tmpDir, 'state.json');
-    fs.writeFileSync(
-      stateFile,
-      JSON.stringify({
-        insiderKeys: {
-          'test@example.com': { seed: 'stateseed', createdAt: '2026-01-01' },
-        },
-      }),
-    );
+  it('uses config seed when present', () => {
     const result = resolveInsiders(
       {
         'test@example.com': {
@@ -162,25 +124,9 @@ describe('resolveInsiders', () => {
         },
       },
       {},
-      stateFile,
     );
     expect(result[0].seed).toBe('configseed');
     expect(result[0].keyCreatedAt).toBe('2026-02-01');
-  });
-
-  it('falls back to state seed when config seed is absent', () => {
-    const stateFile = path.join(tmpDir, 'state.json');
-    fs.writeFileSync(
-      stateFile,
-      JSON.stringify({
-        insiderKeys: {
-          'test@example.com': { seed: 'stateseed', createdAt: '2026-01-01' },
-        },
-      }),
-    );
-    const result = resolveInsiders({ 'test@example.com': {} }, {}, stateFile);
-    expect(result[0].seed).toBe('stateseed');
-    expect(result[0].keyCreatedAt).toBe('2026-01-01');
   });
 });
 
@@ -271,27 +217,7 @@ describe('deriveInternalKey', () => {
   });
 });
 
-vi.mock('@karmaniverous/jeeves', () => ({
-  getConfigRoot: () => buildRuntimeConfigTestConfigRoot,
-  SERVER_PORT: 1934,
-}));
-
-let buildRuntimeConfigTestConfigRoot = '';
-
 describe('buildRuntimeConfig', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jeeves-brc-'));
-    buildRuntimeConfigTestConfigRoot = path.join(tmpDir, 'config');
-    fs.mkdirSync(buildRuntimeConfigTestConfigRoot, { recursive: true });
-  });
-
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-    vi.restoreAllMocks();
-  });
-
   it('constructs correct path fields', () => {
     const config = {
       port: 1934,
@@ -313,47 +239,11 @@ describe('buildRuntimeConfig', () => {
       '/srv/jeeves/config.json',
     );
 
-    const expectedStateDir = path.join(tmpDir, 'state', 'jeeves-server');
-    expect(result.stateFile).toBe(path.join(expectedStateDir, 'state.json'));
-    expect(fs.existsSync(expectedStateDir)).toBe(true);
     expect(result.eventsLog).toBe(
       path.join('/srv/jeeves', 'logs', 'webhook-events.jsonl'),
     );
     expect(result.configPath).toBe('/srv/jeeves/config.json');
     expect(result.port).toBe(1934);
     expect(result.authModes).toEqual(['keys']);
-  });
-
-  it('migrates state.json from old location', () => {
-    const config = {
-      port: 1934,
-      eventTimeoutMs: 30000,
-      eventLogPurgeMs: 2592000000,
-      maxZipSizeMb: 100,
-      chromePath: '/usr/bin/chrome',
-      scopes: {},
-      events: {},
-      auth: { modes: ['keys' as const] },
-      keys: { primary: 'a'.repeat(64) },
-      insiders: {},
-      go: {},
-    } as JeevesConfig;
-
-    const oldRootDir = path.join(tmpDir, 'pkg');
-    fs.mkdirSync(oldRootDir, { recursive: true });
-    const oldState = {
-      insiderKeys: { 'a@b.com': { seed: 'old', createdAt: '2026-01-01' } },
-    };
-    fs.writeFileSync(
-      path.join(oldRootDir, 'state.json'),
-      JSON.stringify(oldState),
-    );
-
-    const result = buildRuntimeConfig(config, oldRootDir, '/cfg.json');
-
-    const newState = JSON.parse(
-      fs.readFileSync(result.stateFile, 'utf8'),
-    ) as unknown;
-    expect(newState).toEqual(oldState);
   });
 });

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -1,14 +1,12 @@
 /**
  * Config resolution — transforms raw validated config into runtime types.
  *
- * Handles: key resolution, insider merging with state, PlantUML server defaults,
+ * Handles: key resolution, insider resolution, PlantUML server defaults,
  * scope normalization, internal key derivation.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-
-import { getConfigRoot } from '@karmaniverous/jeeves';
 
 import { computeInsiderKey } from '../util/crypto.js';
 import type { JeevesConfig } from './schema.js';
@@ -18,7 +16,6 @@ import type {
   ResolvedInsider,
   ResolvedKey,
   RuntimeConfig,
-  ServerState,
 } from './types.js';
 
 /**
@@ -145,8 +142,7 @@ export function resolveKeys(
 }
 
 /**
- * Resolve insider entries by reading seed from config first, falling back to
- * state.json for migration from older versions.
+ * Resolve insider entries from config seeds.
  */
 export function resolveInsiders(
   insiders: Record<
@@ -160,29 +156,15 @@ export function resolveInsiders(
     }
   >,
   namedScopes: Record<string, { allow?: string[]; deny?: string[] }>,
-  stateFile: string,
 ): ResolvedInsider[] {
-  let serverState: ServerState = {};
-  try {
-    if (fs.existsSync(stateFile)) {
-      serverState = JSON.parse(
-        fs.readFileSync(stateFile, 'utf8'),
-      ) as ServerState;
-    }
-  } catch {
-    /* empty state */
-  }
-
   return Object.entries(insiders).map(([rawEmail, entry]) => {
     const email = rawEmail.toLowerCase();
     const scopes = resolveNamedScopes(namedScopes, entry.scopes, {
       allow: entry.allow,
       deny: entry.deny,
     });
-    // Prefer seed from config.json; fall back to state.json for migration
-    const stateKey = serverState.insiderKeys?.[email];
-    const seed = entry.seed ?? stateKey?.seed ?? '';
-    const keyCreatedAt = entry.keyCreatedAt ?? stateKey?.createdAt ?? null;
+    const seed = entry.seed ?? '';
+    const keyCreatedAt = entry.keyCreatedAt ?? null;
     return { email, seed, scopes, keyCreatedAt };
   });
 }
@@ -235,22 +217,6 @@ export function buildRuntimeConfig(
   rootDir: string,
   configPath: string,
 ): RuntimeConfig {
-  const configRoot = getConfigRoot();
-  const stateDir = path.join(
-    path.basename(configRoot) === 'config'
-      ? path.join(path.dirname(configRoot), 'state')
-      : configRoot,
-    'jeeves-server',
-  );
-  fs.mkdirSync(stateDir, { recursive: true });
-  const stateFile = path.join(stateDir, 'state.json');
-
-  // Migrate state.json from old location (package root) if needed
-  const oldStateFile = path.join(rootDir, 'state.json');
-  if (fs.existsSync(oldStateFile) && !fs.existsSync(stateFile)) {
-    fs.copyFileSync(oldStateFile, stateFile);
-  }
-
   const resolvedKeys = resolveKeys(
     config.keys as Record<
       string,
@@ -262,7 +228,6 @@ export function buildRuntimeConfig(
   const resolvedInsiders = resolveInsiders(
     config.insiders,
     config.scopes as Record<string, { allow?: string[]; deny?: string[] }>,
-    stateFile,
   );
 
   return {
@@ -318,7 +283,6 @@ export function buildRuntimeConfig(
     go: config.go,
     configPath,
     eventsLog: path.join(rootDir, 'logs', 'webhook-events.jsonl'),
-    stateFile,
     eventQueuePath: path.join(rootDir, 'logs', 'event-queue.jsonl'),
     eventQueueCursorPath: path.join(rootDir, 'logs', 'event-queue.cursor'),
     eventLogPath: path.join(rootDir, 'logs', 'event-log.jsonl'),

--- a/packages/service/src/config/types.ts
+++ b/packages/service/src/config/types.ts
@@ -86,27 +86,9 @@ export interface RuntimeConfig {
   go: Record<string, string>;
   configPath: string;
   eventsLog: string;
-  stateFile: string;
   eventQueuePath: string;
   eventQueueCursorPath: string;
   eventLogPath: string;
-}
-
-/**
- * Insider key state (auto-generated, persisted in state.json)
- */
-export interface InsiderKeyState {
-  seed: string;
-  createdAt: string;
-}
-
-/**
- * State file structure (mutable runtime state, separate from config)
- */
-export interface ServerState {
-  keyRotatedAt?: string;
-  /** Auto-generated insider keys, keyed by email */
-  insiderKeys?: Record<string, InsiderKeyState>;
 }
 
 /**

--- a/packages/service/src/routes/api/sharing.ts
+++ b/packages/service/src/routes/api/sharing.ts
@@ -18,6 +18,7 @@ import { _pathMatchesScopes } from '../../auth/keys.js';
 import { findInsider } from '../../auth/resolve.js';
 import { getConfig, resetConfig } from '../../config/index.js';
 import { encodeStack } from '../../services/deepShareLinks.js';
+import { writeInsiderSeedToConfig } from '../../util/configPersist.js';
 import {
   computeDeepShareKey,
   computeOutsiderKeyWithExpiry,
@@ -25,7 +26,6 @@ import {
   type DeepShareParams,
 } from '../../util/crypto.js';
 import { fsPathToUrl, getRoots } from '../../util/platform.js';
-import { setInsiderKey } from '../../util/state.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -161,7 +161,7 @@ export const sharingRoutes: FastifyPluginAsync = async (fastify) => {
 
     const newSeed = crypto.randomBytes(32).toString('hex');
     const now = new Date().toISOString();
-    await setInsiderKey(insider.email, newSeed, now);
+    await writeInsiderSeedToConfig(insider.email, newSeed, now);
     resetConfig();
 
     return reply.send({ ok: true, keyCreatedAt: now });

--- a/packages/service/src/routes/auth.ts
+++ b/packages/service/src/routes/auth.ts
@@ -13,7 +13,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { buildAuthUrl, exchangeCode, getUserInfo } from '../auth/google.js';
 import { COOKIE_NAME, createSessionCookie } from '../auth/session.js';
 import { getConfig, resetConfig } from '../config/index.js';
-import { setInsiderKey } from '../util/state.js';
+import { writeInsiderSeedToConfig } from '../util/configPersist.js';
 
 /**
  * Build the redirect URI from the request.
@@ -106,8 +106,7 @@ export const authRoute: FastifyPluginAsync = async (fastify) => {
       const timestamp = new Date().toISOString();
       insider.seed = newSeed;
 
-      // Persist to state.json (mutable runtime state)
-      await setInsiderKey(insider.email, newSeed, timestamp);
+      await writeInsiderSeedToConfig(insider.email, newSeed, timestamp);
       resetConfig(); // Reload to pick up new state
     }
 

--- a/packages/service/src/routes/config.test.ts
+++ b/packages/service/src/routes/config.test.ts
@@ -44,7 +44,6 @@ function makeConfig(overrides: Partial<RuntimeConfig> = {}): RuntimeConfig {
     go: {},
     configPath: '/etc/jeeves-server.config.json',
     eventsLog: '/var/log/events.log',
-    stateFile: '/var/state.json',
     eventQueuePath: '/var/queue.jsonl',
     eventQueueCursorPath: '/var/cursor.json',
     eventLogPath: '/var/event-log.jsonl',

--- a/packages/service/src/routes/keys.ts
+++ b/packages/service/src/routes/keys.ts
@@ -16,13 +16,13 @@ import {
 } from '../auth/resolve.js';
 import { getConfig, resetConfig } from '../config/index.js';
 import { appendEvent } from '../services/eventQueue.js';
+import { writeInsiderSeedToConfig } from '../util/configPersist.js';
 import {
   computeInsiderKey,
   computeOutsiderKeyWithExpiry,
   computePathKey,
   timingSafeEqual,
 } from '../util/crypto.js';
-import { setInsiderKey, setKeyRotationTimestamp } from '../util/state.js';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const keysRoute: FastifyPluginAsync = async (fastify) => {
@@ -159,13 +159,12 @@ async function rotateInsiderSeed(
   const rotatedSeed = crypto.randomBytes(32).toString('hex');
   const timestamp = new Date().toISOString();
 
-  await setInsiderKey(insider.email, rotatedSeed, timestamp);
+  await writeInsiderSeedToConfig(insider.email, rotatedSeed, timestamp);
   appendEvent({
     kind: 'insider_key_rotated',
     email: insider.email,
     at: timestamp,
   });
-  setKeyRotationTimestamp(timestamp);
   resetConfig();
 
   return { ok: true, keyName: insider.email };

--- a/packages/service/src/util/configPersist.ts
+++ b/packages/service/src/util/configPersist.ts
@@ -1,5 +1,7 @@
 /**
- * Server state management (key rotation tracking, etc.)
+ * Persist insider seed data into the config JSON file.
+ *
+ * @packageDocumentation
  */
 
 import crypto from 'node:crypto';
@@ -9,31 +11,6 @@ import path from 'node:path';
 import { withFileLock } from '@karmaniverous/jeeves';
 
 import { getConfig } from '../config/index.js';
-import type { ServerState } from '../config/types.js';
-
-/**
- * Load state from file
- */
-function loadState(): ServerState {
-  const { stateFile } = getConfig();
-  try {
-    if (fs.existsSync(stateFile)) {
-      const content = fs.readFileSync(stateFile, 'utf8');
-      return JSON.parse(content) as ServerState;
-    }
-  } catch {
-    // Ignore errors, return empty state
-  }
-  return {};
-}
-
-/**
- * Save state to file
- */
-function saveState(state: ServerState): void {
-  const { stateFile } = getConfig();
-  fs.writeFileSync(stateFile, JSON.stringify(state, null, 2), 'utf8');
-}
 
 /**
  * Atomically write JSON to a file (write to tmp, then rename).
@@ -53,7 +30,7 @@ function atomicWriteJson(filePath: string, data: unknown): void {
  * Preserves all existing content — only updates the specific insider entry.
  * Uses a file lock to prevent concurrent first-logins from losing updates.
  */
-async function writeInsiderSeedToConfig(
+export async function writeInsiderSeedToConfig(
   email: string,
   seed: string,
   createdAt: string,
@@ -97,32 +74,4 @@ async function writeInsiderSeedToConfig(
       console.warn('Failed to write config for insider seed update:', err);
     }
   });
-}
-
-/**
- * Set key rotation timestamp
- */
-export function setKeyRotationTimestamp(timestamp: string): void {
-  const state = loadState();
-  state.keyRotatedAt = timestamp;
-  saveState(state);
-}
-
-/**
- * Set an insider's auto-generated key.
- * Writes to config.json (primary) and state.json (backward compat).
- */
-export async function setInsiderKey(
-  email: string,
-  seed: string,
-  createdAt: string,
-): Promise<void> {
-  // Write to config.json (primary storage)
-  await writeInsiderSeedToConfig(email, seed, createdAt);
-
-  // Write to state.json (backward compat during transition)
-  const state = loadState();
-  if (!state.insiderKeys) state.insiderKeys = {};
-  state.insiderKeys[email.toLowerCase()] = { seed, createdAt };
-  saveState(state);
 }


### PR DESCRIPTION
## Summary
- Removed `state.json` and all related dead code (`loadState`, `saveState`, `setKeyRotationTimestamp`, `setInsiderKey`, `ServerState`, `InsiderKeyState`, `stateFile`)
- Moved `writeInsiderSeedToConfig` and `atomicWriteJson` from `state.ts` to new `configPersist.ts`
- Simplified `resolveInsiders` to read seeds only from config (no more state.json fallback)
- Updated all callers (auth.ts, sharing.ts, keys.ts) and tests

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (309 tests, 28 files)
- [x] `npx stan run --sequential --no-archive` passes (knip failures are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)