### PR TITLE
fix: upgrade client eslint to v10, fix lint errors from stricter rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16563,12 +16563,12 @@
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.1",
+        "@eslint/js": "^10.0.1",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
-        "eslint": "^9.39.1",
+        "eslint": "^10.2.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
@@ -16577,70 +16577,25 @@
         "vite": "^8.0.3"
       }
     },
-    "packages/service/node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "packages/service/node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "packages/service/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "packages/service/node_modules/@eslint/js": {
-      "version": "9.39.4",
+    "packages/service/client/node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      }
-    },
-    "packages/service/node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "packages/service/node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "packages/service/node_modules/ajv": {
@@ -16657,169 +16612,9 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "packages/service/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/service/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "packages/service/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/service/node_modules/eslint": {
-      "version": "9.39.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "packages/service/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "packages/service/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "packages/service/node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/service/node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/service/node_modules/espree": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "packages/service/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "packages/service/node_modules/minimatch": {
-      "version": "3.1.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "packages/shared": {
       "name": "@karmaniverous/jeeves-server-shared",

--- a/packages/service/client/package.json
+++ b/packages/service/client/package.json
@@ -44,12 +44,12 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.1",
+    "@eslint/js": "^10.0.1",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "eslint": "^9.39.1",
+    "eslint": "^10.2.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -217,18 +217,8 @@ export function buildRuntimeConfig(
   rootDir: string,
   configPath: string,
 ): RuntimeConfig {
-  const resolvedKeys = resolveKeys(
-    config.keys as Record<
-      string,
-      | string
-      | { key: string; scopes?: unknown; allow?: string[]; deny?: string[] }
-    >,
-    config.scopes as Record<string, { allow?: string[]; deny?: string[] }>,
-  );
-  const resolvedInsiders = resolveInsiders(
-    config.insiders,
-    config.scopes as Record<string, { allow?: string[]; deny?: string[] }>,
-  );
+  const resolvedKeys = resolveKeys(config.keys, config.scopes);
+  const resolvedInsiders = resolveInsiders(config.insiders, config.scopes);
 
   return {
     port: config.port,
@@ -242,7 +232,7 @@ export function buildRuntimeConfig(
     plantuml: resolvePlantuml(config.plantuml, rootDir),
     outsiderPolicy:
       resolveNamedScopes(
-        config.scopes as Record<string, { allow?: string[]; deny?: string[] }>,
+        config.scopes,
         (config.outsiderPolicy as unknown) &&
           typeof config.outsiderPolicy === 'object' &&
           !Array.isArray(config.outsiderPolicy)
@@ -269,15 +259,7 @@ export function buildRuntimeConfig(
     oauth: config.oauth
       ? {
           credentialDir: config.oauth.credentialDir,
-          providers: config.oauth.providers as Record<
-            string,
-            {
-              authUrl: string;
-              tokenUrl: string;
-              pkce: boolean;
-              defaultScopes: string[];
-            }
-          >,
+          providers: config.oauth.providers,
         }
       : null,
     go: config.go,

--- a/packages/service/src/routes/api/diagramExport.test.ts
+++ b/packages/service/src/routes/api/diagramExport.test.ts
@@ -108,7 +108,7 @@ describe('diagramExportRoutes', () => {
         routePath: string,
         handler: (req: unknown, reply: unknown) => Promise<void>,
       ) => {
-        routes[routePath] = handler as (typeof routes)[string];
+        routes[routePath] = handler;
       },
     };
 

--- a/packages/service/src/routes/api/export.ts
+++ b/packages/service/src/routes/api/export.ts
@@ -16,7 +16,7 @@ import type { FastifyPluginAsync } from 'fastify';
 
 import { getConfig } from '../../config/index.js';
 import { appendEvent } from '../../services/eventQueue.js';
-import { type ExportFormat, exportPage } from '../../services/export.js';
+import { exportPage } from '../../services/export.js';
 import {
   cacheExport,
   clearDiagramCacheForFile,
@@ -133,7 +133,7 @@ export const exportRoutes: FastifyPluginAsync = async (fastify) => {
         const buffer = await exportPage({
           url: exportUrl,
           fileName,
-          format: format as ExportFormat,
+          format: format,
         });
 
         // Cache the result

--- a/packages/service/src/services/plantuml.ts
+++ b/packages/service/src/services/plantuml.ts
@@ -45,19 +45,13 @@ function renderViaJar(filePath: string, format: string): Buffer | null {
     if (fs.existsSync(outFile)) {
       console.warn('[PlantUML jar] render completed with warnings');
       if (err && typeof err === 'object' && 'stderr' in err) {
-        console.warn(
-          '[PlantUML jar] stderr:',
-          String((err as { stderr: unknown }).stderr),
-        );
+        console.warn('[PlantUML jar] stderr:', String(err.stderr));
       }
       return fs.readFileSync(outFile);
     }
     console.error('[PlantUML jar] render failed:', (err as Error).message);
     if (err && typeof err === 'object' && 'stderr' in err) {
-      console.error(
-        '[PlantUML jar] stderr:',
-        String((err as { stderr: unknown }).stderr),
-      );
+      console.error('[PlantUML jar] stderr:', String(err.stderr));
     }
     return null;
   } finally {


### PR DESCRIPTION
Follow-up to #195 (merged). Upgrades service/client from eslint 9 to eslint 10 to match root, fixing nested eslint resolution that broke lint on both CI and local. Auto-fixes unnecessary type assertions surfaced by eslint 10.