### PR TITLE
chore: add files whitelists and npm-pack-check CI workflow

### DIFF
--- a/.github/workflows/npm-pack-check.yml
+++ b/.github/workflows/npm-pack-check.yml
@@ -1,0 +1,11 @@
+name: npm Pack Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pack-check:
+    uses: karmaniverous/gha-workflows/.github/workflows/npm-pack-check.yml@main

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@karmaniverous/jeeves-server-core",
   "version": "0.1.0",
   "type": "module",
+  "files": ["dist"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -36,6 +36,7 @@
     "knip": "knip",
     "release:pre": "dotenvx run -f .env.local -- release-it --no-git.requireBranch --github.prerelease --preRelease"
   },
+  "files": ["dist"],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Adds `"files": ["dist"]` whitelists to packages/core and packages/service package.json files. Adds reusable npm-pack-check workflow to CI. Ensures no forbidden files (*.local etc.) leak into published tarballs.