### PR TITLE
fix: edit-cell line offset — resolve td/th to table, not tr

### DIFF
--- a/packages/service/client/src/components/BlockHoverControls.tsx
+++ b/packages/service/client/src/components/BlockHoverControls.tsx
@@ -212,7 +212,7 @@ export function BlockHoverControls({
   const getSourceRange = useCallback((el: Element) => {
     const tag = el.tagName.toLowerCase();
     if (tag === 'td' || tag === 'th') {
-      const table = el.closest('[data-source-start]');
+      const table = el.closest('table[data-source-start]');
       if (table) {
         const start = parseInt(table.getAttribute('data-source-start') ?? '0', 10);
         const end = parseInt(table.getAttribute('data-source-end') ?? '0', 10);
@@ -251,7 +251,7 @@ export function BlockHoverControls({
         const row = el.closest('tr');
         const table = el.closest('table');
         if (!row || !table) return;
-        const { startLine: tableStart } = getSourceRange(el);
+        const tableStart = parseInt(table.getAttribute('data-source-start') ?? '0', 10);
         if (!tableStart) return;
 
         const isHeader = row.closest('thead') !== null;


### PR DESCRIPTION
## Bug

Inline table cell edits (edit-cell mutation) land in the correct column but two rows below the intended row.

## Root Cause

`getSourceRange()` in `BlockHoverControls.tsx` uses `el.closest('[data-source-start]')` to find the table's source line range for a `<td>`/`<th>`. However, markdown-it's source mapping core rule adds `data-source-start` to **all** block-level opening tokens — including `<tr>`, `<tbody>`, and `<thead>`, not just `<table>`.

So `closest('[data-source-start]')` on a `<td>` matches its parent `<tr>` first, returning that row's own source line instead of the table's first line. `handleEdit` then computes:

```
rowLine = trStartLine + 2 + rowIndex
```

…where the `+2` is meant to skip the header row and separator row from the **table** start. Starting from the row's own line adds an extra +2 offset.

## Fix

1. **`getSourceRange`**: Changed `el.closest('[data-source-start]')` → `el.closest('table[data-source-start]')` so it always resolves to the `<table>` element for cells.
2. **`handleEdit`**: Reads `data-source-start` directly from the `<table>` element (already referenced) instead of going through `getSourceRange`.
