### PR TITLE
fix: include scripts/ in service package files for postinstall

### DIFF
--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -36,7 +36,7 @@
     "knip": "knip",
     "release:pre": "dotenvx run -f .env.local -- release-it --no-git.requireBranch --github.prerelease --preRelease"
   },
-  "files": ["dist"],
+  "files": ["dist", "scripts"],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Fix

The `postinstall` script references `scripts/download-plantuml.js`, but the `files` whitelist only includes `dist`. This causes `npm install -g` to fail with `MODULE_NOT_FOUND` because the script isn't shipped in the package.

Adds `"scripts"` to the `files` array in `packages/service/package.json`.

Follow-up to #206.
