### PR TITLE
chore: add missing npm metadata to core package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@karmaniverous/jeeves-server-core",
   "version": "0.1.1",
+  "author": "Jeeves",
+  "description": "Shared cryptographic utilities and API types for jeeves-server packages.",
+  "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/karmaniverous/jeeves-server.git",
+    "directory": "packages/core"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Adds uthor, description, license, and epository fields to packages/core/package.json for consistency with sibling packages (service, openclaw) and cross-repo alignment with jeeves-runner-core.