### PR TITLE
fix: pin jeeves-server-core dependency to ^0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13828,7 +13828,7 @@
     },
     "packages/core": {
       "name": "@karmaniverous/jeeves-server-core",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
@@ -14065,11 +14065,11 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-server-openclaw",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
-        "@karmaniverous/jeeves-server-core": "*",
+        "@karmaniverous/jeeves-server-core": "^0.1.2",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -14306,14 +14306,14 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-server",
-      "version": "3.10.8",
+      "version": "3.10.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/static": "^8.3.0",
         "@karmaniverous/jeeves": "^0.5.10",
-        "@karmaniverous/jeeves-server-core": "*",
+        "@karmaniverous/jeeves-server-core": "^0.1.2",
         "@karmaniverous/jsonmap": "^2.1.1",
         "@mermaid-js/mermaid-cli": "^11.14.0",
         "@turbodocx/html-to-docx": "^1.20.1",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@karmaniverous/jeeves": "^0.5.10",
-    "@karmaniverous/jeeves-server-core": "*",
+    "@karmaniverous/jeeves-server-core": "^0.1.2",
     "zod": "^4.4.3"
   }
 }

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -53,7 +53,7 @@
     "@fastify/cookie": "^11.0.2",
     "@fastify/static": "^8.3.0",
     "@karmaniverous/jeeves": "^0.5.10",
-    "@karmaniverous/jeeves-server-core": "*",
+    "@karmaniverous/jeeves-server-core": "^0.1.2",
     "@karmaniverous/jsonmap": "^2.1.1",
     "@mermaid-js/mermaid-cli": "^11.14.0",
     "@turbodocx/html-to-docx": "^1.20.1",


### PR DESCRIPTION
Pin @karmaniverous/jeeves-server-core from * to ^0.1.2 in both packages/service and packages/openclaw.