### PR TITLE
fix: strip fragment from deep share link href before path resolution

### DIFF
--- a/packages/service/src/services/deepShareLinks.test.ts
+++ b/packages/service/src/services/deepShareLinks.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for deep share link rewriting — fragment handling.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { rewriteLinksForDeepShare } from './deepShareLinks.js';
+
+const seed = 'test-seed-12345';
+
+describe('rewriteLinksForDeepShare', () => {
+  describe('fragment handling', () => {
+    it('should place fragment after query params for relative links', () => {
+      const html = '<a href="Analysis.md#p01-fix">Link</a>';
+      const result = rewriteLinksForDeepShare(
+        html,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        undefined,
+      );
+      // Fragment must come after all query params (cheerio encodes & as &amp;)
+      expect(result).toMatch(/\?key=.*&amp;d=.*&amp;s=.*#p01-fix/);
+      // Must NOT have #fragment before ?
+      expect(result).not.toMatch(/#p01-fix\?/);
+    });
+
+    it('should place fragment after query params for absolute /browse/ links', () => {
+      const html = '<a href="/browse/repo/Analysis.md#section2">Link</a>';
+      const result = rewriteLinksForDeepShare(
+        html,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        undefined,
+      );
+      expect(result).toMatch(/\?key=.*#section2/);
+      expect(result).not.toMatch(/#section2\?/);
+    });
+
+    it('should place fragment after query params for absolute / links', () => {
+      const html = '<a href="/repo/Analysis.md#heading">Link</a>';
+      const result = rewriteLinksForDeepShare(
+        html,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        undefined,
+      );
+      expect(result).toMatch(/\?key=.*#heading/);
+      expect(result).not.toMatch(/#heading\?/);
+    });
+
+    it('should not include fragment in the target path used for key computation', () => {
+      const htmlWithFragment = '<a href="Analysis.md#frag">Link</a>';
+      const htmlWithout = '<a href="Analysis.md">Link</a>';
+
+      const resultWith = rewriteLinksForDeepShare(
+        htmlWithFragment,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        undefined,
+      );
+      const resultWithout = rewriteLinksForDeepShare(
+        htmlWithout,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        undefined,
+      );
+
+      // Extract key from both — should be identical since fragment is not part of path
+      const keyWith = resultWith.match(/key=([a-f0-9]+)/)?.[1];
+      const keyWithout = resultWithout.match(/key=([a-f0-9]+)/)?.[1];
+      expect(keyWith).toBe(keyWithout);
+    });
+
+    it('should work correctly for links without fragments', () => {
+      const html = '<a href="Analysis.md">Link</a>';
+      const result = rewriteLinksForDeepShare(
+        html,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        undefined,
+      );
+      expect(result).toMatch(/\?key=/);
+      expect(result).not.toContain('#');
+    });
+
+    it('should leave pure anchor links unchanged', () => {
+      const html = '<a href="#section">Link</a>';
+      const result = rewriteLinksForDeepShare(
+        html,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        undefined,
+      );
+      expect(result).toBe('<a href="#section">Link</a>');
+    });
+
+    it('should handle fragment with exp parameter', () => {
+      const html = '<a href="Analysis.md#frag">Link</a>';
+      const result = rewriteLinksForDeepShare(
+        html,
+        seed,
+        '/repo/README.md',
+        2,
+        false,
+        '',
+        '2099-01-01',
+      );
+      // exp should come before fragment (cheerio encodes & as &amp;)
+      expect(result).toMatch(/&amp;exp=2099-01-01#frag/);
+    });
+  });
+});

--- a/packages/service/src/services/deepShareLinks.ts
+++ b/packages/service/src/services/deepShareLinks.ts
@@ -89,7 +89,7 @@ function computeSubLink(
   // Build URL
   let url = `/browse${targetUrlPath}?key=${key}&d=${String(maxDepth)}&dirs=${dirs ? '1' : '0'}&s=${compressedStack}`;
   if (exp) url += `&exp=${exp}`;
-  if (fragment) url += `#${fragment}`;
+  if (fragment !== undefined) url += `#${fragment}`;
   return url;
 }
 

--- a/packages/service/src/services/deepShareLinks.ts
+++ b/packages/service/src/services/deepShareLinks.ts
@@ -55,6 +55,7 @@ function computeSubLink(
   dirs: boolean,
   exp: string | undefined,
   isDirectory: boolean,
+  fragment?: string,
 ): string | null {
   // Check if directories are allowed
   if (isDirectory && !dirs) return null;
@@ -88,6 +89,7 @@ function computeSubLink(
   // Build URL
   let url = `/browse${targetUrlPath}?key=${key}&d=${String(maxDepth)}&dirs=${dirs ? '1' : '0'}&s=${compressedStack}`;
   if (exp) url += `&exp=${exp}`;
+  if (fragment) url += `#${fragment}`;
   return url;
 }
 
@@ -149,18 +151,25 @@ export function rewriteLinksForDeepShare(
     // Raw file links — leave as-is (these are for images/downloads)
     if (href.startsWith('/api/raw/')) return;
 
+    // Strip fragment before resolving path, preserve it for later
+    const hashIndex = href.indexOf('#');
+    const hrefWithoutFragment =
+      hashIndex >= 0 ? href.substring(0, hashIndex) : href;
+    const fragment = hashIndex >= 0 ? href.substring(hashIndex + 1) : undefined;
+
     // Determine target path
     let targetPath: string;
-    if (href.startsWith('/browse/')) {
-      targetPath = '/' + href.replace('/browse/', '').split('?')[0];
-    } else if (href.startsWith('/')) {
-      targetPath = href.split('?')[0];
+    if (hrefWithoutFragment.startsWith('/browse/')) {
+      targetPath =
+        '/' + hrefWithoutFragment.replace('/browse/', '').split('?')[0];
+    } else if (hrefWithoutFragment.startsWith('/')) {
+      targetPath = hrefWithoutFragment.split('?')[0];
     } else {
       // Relative link — resolve against current path directory
       const dir = currentPath.substring(0, currentPath.lastIndexOf('/'));
       targetPath = dir
-        ? `${dir}/${href.split('?')[0]}`
-        : `/${href.split('?')[0]}`;
+        ? `${dir}/${hrefWithoutFragment.split('?')[0]}`
+        : `/${hrefWithoutFragment.split('?')[0]}`;
     }
 
     // Normalize
@@ -175,6 +184,7 @@ export function rewriteLinksForDeepShare(
       dirs,
       exp,
       isDirectory,
+      fragment,
     );
 
     if (subLink === null) {


### PR DESCRIPTION
## Summary
- Fixes #217: Deep share links with `#fragment` identifiers break auth because the fragment was included in the target path, placing `#` before query params
- Strips fragment from `href` before resolving target path in all three parsing branches (absolute `/browse/...`, absolute `/...`, and relative)
- Appends fragment after all query params in `computeSubLink` so the browser correctly sends auth params to the server
- Adds 7 test cases covering fragment handling for all link types

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 316 tests pass (`npm test`)
- [x] Lint passes with zero errors and zero warnings (`npm run lint`)
- [ ] Manual verification: share a page containing `[Link](File.md#section)` and confirm the rewritten URL has `?key=...&d=...#section` (fragment last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)