### PR TITLE
fix: thread auth key through Puppeteer export for raw image resolution (#220)

### DIFF
--- a/packages/service/src/routes/api/export.ts
+++ b/packages/service/src/routes/api/export.ts
@@ -134,6 +134,7 @@ export const exportRoutes: FastifyPluginAsync = async (fastify) => {
           url: exportUrl,
           fileName,
           format: format,
+          authKey: exportKey,
         });
 
         // Cache the result

--- a/packages/service/src/services/export.ts
+++ b/packages/service/src/services/export.ts
@@ -11,6 +11,7 @@ import {
   addPrintStyles,
   captureSvgsAsPng,
   launchBrowser,
+  setupAuthInterception,
   SVG_CONTAINER_SELECTORS,
   waitForSpaContent,
 } from './puppeteer.js';
@@ -21,6 +22,8 @@ interface ExportOptions {
   url: string;
   fileName: string;
   format: ExportFormat;
+  /** Internal auth key appended to `/api/raw/` sub-resource requests. */
+  authKey?: string;
 }
 
 // Max bounds for images in DOCX (6 inches × 8 inches at 96dpi)
@@ -34,6 +37,9 @@ async function exportPDF(options: ExportOptions): Promise<Buffer> {
   const browser = await launchBrowser();
   try {
     const page = await browser.newPage();
+    if (options.authKey) {
+      await setupAuthInterception(page, options.authKey);
+    }
     await page.goto(options.url, { waitUntil: 'networkidle0' });
     await waitForSpaContent(page);
     await addPrintStyles(page);
@@ -57,6 +63,9 @@ async function exportDOCX(options: ExportOptions): Promise<Buffer> {
   const browser = await launchBrowser();
   try {
     const page = await browser.newPage();
+    if (options.authKey) {
+      await setupAuthInterception(page, options.authKey);
+    }
     await page.setViewport({ width: 1200, height: 800 });
     await page.goto(options.url, { waitUntil: 'networkidle0' });
     await waitForSpaContent(page);

--- a/packages/service/src/services/export.ts
+++ b/packages/service/src/services/export.ts
@@ -38,7 +38,7 @@ async function exportPDF(options: ExportOptions): Promise<Buffer> {
   try {
     const page = await browser.newPage();
     if (options.authKey) {
-      await setupAuthInterception(page, options.authKey);
+      await setupAuthInterception(page, options.authKey, options.url);
     }
     await page.goto(options.url, { waitUntil: 'networkidle0' });
     await waitForSpaContent(page);
@@ -64,7 +64,7 @@ async function exportDOCX(options: ExportOptions): Promise<Buffer> {
   try {
     const page = await browser.newPage();
     if (options.authKey) {
-      await setupAuthInterception(page, options.authKey);
+      await setupAuthInterception(page, options.authKey, options.url);
     }
     await page.setViewport({ width: 1200, height: 800 });
     await page.goto(options.url, { waitUntil: 'networkidle0' });

--- a/packages/service/src/services/puppeteer.ts
+++ b/packages/service/src/services/puppeteer.ts
@@ -1,6 +1,8 @@
 /**
  * Puppeteer browser management and page preparation utilities.
  * Shared by PDF and DOCX export paths.
+ *
+ * @packageDocumentation
  */
 
 import type { Browser, Page } from 'puppeteer-core';
@@ -77,6 +79,28 @@ const PRINT_CSS = `
   }
   img { object-fit: contain !important; }
 `;
+
+/**
+ * Intercept requests matching `/api/raw/` and append an auth key.
+ *
+ * Must be called **before** `page.goto()` so the interception is active
+ * when the browser fetches sub-resources (images, etc.).
+ */
+export async function setupAuthInterception(
+  page: Page,
+  authKey: string,
+): Promise<void> {
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    const url = new URL(req.url());
+    if (url.pathname.startsWith('/api/raw/')) {
+      url.searchParams.set('key', authKey);
+      void req.continue({ url: url.toString() });
+    } else {
+      void req.continue();
+    }
+  });
+}
 
 /**
  * Add print styles to a Puppeteer page.

--- a/packages/service/src/services/puppeteer.ts
+++ b/packages/service/src/services/puppeteer.ts
@@ -89,14 +89,23 @@ const PRINT_CSS = `
 export async function setupAuthInterception(
   page: Page,
   authKey: string,
+  baseUrl: string,
 ): Promise<void> {
+  const allowedOrigin = new URL(baseUrl).origin;
   await page.setRequestInterception(true);
   page.on('request', (req) => {
-    const url = new URL(req.url());
-    if (url.pathname.startsWith('/api/raw/')) {
-      url.searchParams.set('key', authKey);
-      void req.continue({ url: url.toString() });
-    } else {
+    try {
+      const url = new URL(req.url());
+      if (
+        url.origin === allowedOrigin &&
+        url.pathname.startsWith('/api/raw/')
+      ) {
+        url.searchParams.set('key', authKey);
+        void req.continue({ url: url.toString() });
+      } else {
+        void req.continue();
+      }
+    } catch {
       void req.continue();
     }
   });


### PR DESCRIPTION
Fixes #220

## Problem

When Markdown files reference images via `/api/raw/...` paths, images render in the browser but break in PDF and DOCX exports. Puppeteer launches a fresh headless browser with no session cookies. The export route passes `?key=` on the initial page URL, but subsequent sub-resource requests (like `<img src='/api/raw/...'>`\ ) don't carry the key, so the API middleware returns 401.

## Solution

Added Puppeteer request interception that appends the internal auth key to any request whose pathname starts with `/api/raw/`.

### Changes

- **`puppeteer.ts`** — New `setupAuthInterception(page, authKey)` helper that intercepts requests matching `/api/raw/` and appends `?key=<authKey>`  
- **`export.ts`** — Added optional `authKey` to `ExportOptions`; both `exportPDF` and `exportDOCX` call the interception helper before `page.goto()`  
- **`routes/api/export.ts`** — Threads `exportKey` into the `exportPage` call

### Quality

- typecheck ✅
- lint ✅
- test ✅
- build ✅