### PR TITLE
fix: service package files + background status health checks

### DIFF
--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -53,6 +53,7 @@
   },
   "files": [
     "dist",
+    "content",
     "scripts"
   ],
   "keywords": [

--- a/packages/service/src/routes/status.test.ts
+++ b/packages/service/src/routes/status.test.ts
@@ -43,12 +43,13 @@ describe('GET /status', () => {
   it('returns structured status with SDK shape', async () => {
     // Create a minimal Fastify-like test harness
     const routes: Record<string, (req: unknown) => Promise<unknown>> = {};
+    const closeHooks: (() => Promise<void>)[] = [];
     const fakeFastify = {
       get: (path: string, handler: (req: unknown) => Promise<unknown>) => {
         routes[path] = handler;
       },
-      addHook: (_hook: string, _handler: unknown) => {
-        // no-op for test harness
+      addHook: (hook: string, handler: () => Promise<void>) => {
+        if (hook === 'onClose') closeHooks.push(handler);
       },
     };
 
@@ -90,5 +91,8 @@ describe('GET /status', () => {
     expect(services).toHaveProperty('watcher');
     expect(services).toHaveProperty('runner');
     expect(services).toHaveProperty('meta');
+
+    // Clean up background interval
+    await Promise.all(closeHooks.map((hook) => hook()));
   });
 });

--- a/packages/service/src/routes/status.test.ts
+++ b/packages/service/src/routes/status.test.ts
@@ -47,6 +47,9 @@ describe('GET /status', () => {
       get: (path: string, handler: (req: unknown) => Promise<unknown>) => {
         routes[path] = handler;
       },
+      addHook: (_hook: string, _handler: unknown) => {
+        // no-op for test harness
+      },
     };
 
     await statusRoutes(fakeFastify as never, {});
@@ -81,5 +84,11 @@ describe('GET /status', () => {
     expect(exports.diagrams).toEqual(['svg', 'png']);
     expect(exports.chromeAvailable).toBe(true);
     expect((health.diagrams as { mermaid: boolean }).mermaid).toBe(true);
+
+    // Services should be present (cache may or may not have populated)
+    const services = health.services as Record<string, unknown>;
+    expect(services).toHaveProperty('watcher');
+    expect(services).toHaveProperty('runner');
+    expect(services).toHaveProperty('meta');
   });
 });

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -3,6 +3,9 @@
  *
  * Returns standard `{ name, version, uptime, status, health }` shape
  * with server-specific details nested under `health`.
+ *
+ * Service health checks (watcher, runner, meta) are cached in the
+ * background on a 60-second interval to avoid blocking the response.
  */
 
 import { createStatusHandler, getServiceUrl } from '@karmaniverous/jeeves';
@@ -11,17 +14,35 @@ import type { FastifyPluginAsync } from 'fastify';
 import { getConfig } from '../config/index.js';
 import { packageVersion } from '../util/packageVersion.js';
 
+/** Health status of a single downstream service. */
 interface ServiceStatus {
   url: string;
   reachable: boolean;
   version?: string;
 }
 
+/** Background cache for downstream service health checks. */
+interface ServiceCache {
+  watcher: ServiceStatus;
+  runner: ServiceStatus;
+  meta: ServiceStatus;
+  lastChecked: string;
+}
+
+let serviceCache: ServiceCache | null = null;
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Probe a single service's health endpoint.
+ *
+ * Tries `/status` then `/health`, returning the first successful
+ * response. Times out after 1 500 ms per attempt.
+ */
 async function checkService(url: string): Promise<ServiceStatus> {
   for (const endpoint of ['/status', '/health']) {
     try {
       const res = await fetch(`${url}${endpoint}`, {
-        signal: AbortSignal.timeout(3000),
+        signal: AbortSignal.timeout(1500),
       });
       if (res.ok) {
         const data = (await res.json()) as { version?: string };
@@ -34,17 +55,51 @@ async function checkService(url: string): Promise<ServiceStatus> {
   return { url, reachable: false };
 }
 
+/** Refresh the background service-health cache. */
+async function refreshServiceCache(): Promise<void> {
+  const [watcher, runner, meta] = await Promise.all([
+    checkService(getServiceUrl('watcher')),
+    checkService(getServiceUrl('runner')),
+    checkService(getServiceUrl('meta')),
+  ]);
+
+  serviceCache = {
+    watcher,
+    runner,
+    meta,
+    lastChecked: new Date().toISOString(),
+  };
+}
+
 const handleStatus = createStatusHandler({
   name: 'server',
   version: packageVersion,
+  // eslint-disable-next-line @typescript-eslint/require-await
   getHealth: async () => {
     const config = getConfig();
 
-    const [watcher, runner, meta] = await Promise.all([
-      checkService(getServiceUrl('watcher')),
-      checkService(getServiceUrl('runner')),
-      checkService(getServiceUrl('meta')),
-    ]);
+    const services = serviceCache
+      ? {
+          watcher: serviceCache.watcher,
+          runner: serviceCache.runner,
+          meta: serviceCache.meta,
+          lastChecked: serviceCache.lastChecked,
+        }
+      : {
+          watcher: {
+            url: getServiceUrl('watcher'),
+            reachable: false,
+          },
+          runner: {
+            url: getServiceUrl('runner'),
+            reachable: false,
+          },
+          meta: {
+            url: getServiceUrl('meta'),
+            reachable: false,
+          },
+          lastChecked: null,
+        };
 
     return {
       port: config.port,
@@ -74,17 +129,30 @@ const handleStatus = createStatusHandler({
           servers: config.plantuml.servers,
         },
       },
-      services: {
-        watcher,
-        runner,
-        meta,
-      },
+      services,
     };
   },
 });
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const statusRoutes: FastifyPluginAsync = async (fastify) => {
+  // Fire-and-forget initial cache population.
+  void refreshServiceCache();
+
+  // Refresh every 60 seconds.
+  refreshTimer = setInterval(() => {
+    void refreshServiceCache();
+  }, 60_000);
+
+  // Clean up on shutdown.
+  // eslint-disable-next-line @typescript-eslint/require-await
+  fastify.addHook('onClose', async () => {
+    if (refreshTimer) {
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+  });
+
   fastify.get('/status', async () => {
     const result = await handleStatus();
     return result.body;

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -30,7 +30,6 @@ interface ServiceCache {
 }
 
 let serviceCache: ServiceCache | null = null;
-let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
  * Probe a single service's health endpoint.
@@ -57,18 +56,22 @@ async function checkService(url: string): Promise<ServiceStatus> {
 
 /** Refresh the background service-health cache. */
 async function refreshServiceCache(): Promise<void> {
-  const [watcher, runner, meta] = await Promise.all([
-    checkService(getServiceUrl('watcher')),
-    checkService(getServiceUrl('runner')),
-    checkService(getServiceUrl('meta')),
-  ]);
+  try {
+    const [watcher, runner, meta] = await Promise.all([
+      checkService(getServiceUrl('watcher')),
+      checkService(getServiceUrl('runner')),
+      checkService(getServiceUrl('meta')),
+    ]);
 
-  serviceCache = {
-    watcher,
-    runner,
-    meta,
-    lastChecked: new Date().toISOString(),
-  };
+    serviceCache = {
+      watcher,
+      runner,
+      meta,
+      lastChecked: new Date().toISOString(),
+    };
+  } catch (error) {
+    console.error('Failed to refresh service status cache:', error);
+  }
 }
 
 const handleStatus = createStatusHandler({
@@ -136,6 +139,8 @@ const handleStatus = createStatusHandler({
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const statusRoutes: FastifyPluginAsync = async (fastify) => {
+  let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
   // Fire-and-forget initial cache population.
   void refreshServiceCache();
 


### PR DESCRIPTION
## Changes

### Fix 1: Add content/ to service package files field (#200)
The \iles\ field in \packages/service/package.json\ was missing \content/\, causing \content/privacy.md\ and \content/terms.md\ to be excluded from npm packages. Fresh installs would get 404s on \GET /api/content-link/:file\.

### Fix 2: Background-cache service health checks in /status (#177)
The \/status\ endpoint was running \Promise.all([checkService(...)])\ synchronously inside the GET handler, blocking the response for up to 3 seconds when services were unreachable.

Changed to a background-cache approach:
- Service health is refreshed every 60 seconds in the background
- Per-fetch timeout reduced from 3000ms to 1500ms
- \/status\ reads from cache synchronously (instant response)
- Cache includes \lastChecked\ timestamp
- Interval is cleaned up via Fastify \onClose\ hook
- If cache is not yet populated, services report \eachable: false\ with \lastChecked: null\

Closes #200, closes #177