### PR TITLE
feat: next version release (#210, #211, #213, #214)

### DIFF
--- a/.github/workflows/linux-compat.yml
+++ b/.github/workflows/linux-compat.yml
@@ -98,12 +98,21 @@ jobs:
           echo "README.md status: $HTTP_CODE"
           [ "$HTTP_CODE" = "200" ] || (echo "FAIL: README.md returned $HTTP_CODE" && exit 1)
 
-      - name: Smoke test - SPA loads
+      - name: Smoke test - SPA loads (authenticated)
+        run: |
+          RESPONSE=$(curl -s -w "\n%{http_code}" "http://localhost:1934/browse?key=$INSIDER_KEY")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          echo "SPA (authenticated) status: $HTTP_CODE"
+          [ "$HTTP_CODE" = "200" ] || (echo "FAIL: SPA didn't load with key" && exit 1)
+
+      - name: Smoke test - SPA auth gate (unauthenticated)
         run: |
           RESPONSE=$(curl -s -w "\n%{http_code}" http://localhost:1934/browse)
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          echo "SPA status: $HTTP_CODE"
-          [ "$HTTP_CODE" = "200" ] || (echo "FAIL: SPA didn't load" && exit 1)
+          echo "SPA (unauthenticated) status: $HTTP_CODE"
+          [ "$HTTP_CODE" = "401" ] || (echo "FAIL: expected 401 for unauthenticated SPA, got $HTTP_CODE" && exit 1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+          echo "$BODY" | grep -q "Sign in to continue" || (echo "FAIL: sign-in page not rendered" && exit 1)
 
       - name: Stop server
         if: always()

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ jeeves-server init --config /path/to/config-dir
 jeeves-server start --config /path/to/jeeves-server/config.json
 ```
 
-Configuration is validated at startup against a [Zod 4](https://github.com/colinhacks/zod) schema. The schema in `packages/service/src/config/schema.ts` is the single source of truth.
+Configuration is validated at startup against a [Zod 4](https://github.com/colinhacks/zod) schema. The schema in `packages/core/src/schema.ts` is the single source of truth (re-exported by the service package).
 
 **Environment variable substitution:** Use `${VAR_NAME}` in string config values and they'll be replaced from `process.env` at load time.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14667,7 +14667,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-server-openclaw",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.12",
@@ -14695,7 +14695,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-server",
-      "version": "3.10.13",
+      "version": "3.10.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -14715,12 +14715,12 @@
         "markdown-it-anchor": "^9.2.0",
         "markdown-it-task-lists": "^2.1.1",
         "mime-types": "^3.0.2",
-        "package-directory": "^8.2.0",
         "picomatch": "^4.0.4",
         "plantuml-encoder": "^1.4.0",
         "puppeteer": "^24.43.1",
         "puppeteer-core": "^23.11.1",
-        "radash": "^12.1.1"
+        "radash": "^12.1.1",
+        "zod": "^4.4.3"
       },
       "bin": {
         "jeeves-server": "dist/src/cli/index.js"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -14,6 +14,21 @@ Shared workspace package providing cryptographic utilities and API types consume
 | `computeDeepShareKey(seed, path, params)` | HMAC-SHA256 key for deep directory shares with depth/dirs/stack/expiry |
 | `timingSafeEqual(a, b)` | Constant-time string comparison to prevent timing attacks |
 
+### Config Schema
+
+| Export | Description |
+|--------|-------------|
+| `loggingConfigSchema` | Zod schema for `logging` config block (`level`, `file`, both optional) |
+| `LoggingConfig` | Inferred TypeScript type from `loggingConfigSchema` |
+| `jeevesConfigSchema` | Full server config Zod schema (includes `logging`, `oauth`, all other fields) |
+
+### Endpoint Catalog
+
+| Export | Description |
+|--------|-------------|
+| `EndpointEntry` | Interface describing a single API operation (method, path, description, auth flags) |
+| `serverEndpoints` | Complete declarative catalog of all jeeves-server API endpoints (38 entries) |
+
 ### API Types
 
 | Type | Description |
@@ -36,6 +51,9 @@ Shared workspace package providing cryptographic utilities and API types consume
 import {
   computeInsiderKey,
   computePathKey,
+  serverEndpoints,
+  type EndpointEntry,
+  type LoggingConfig,
   type ShareRequest,
 } from '@karmaniverous/jeeves-server-core';
 ```

--- a/packages/core/src/endpoints.test.ts
+++ b/packages/core/src/endpoints.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { serverEndpoints } from './endpoints.js';
+
+describe('serverEndpoints catalog', () => {
+  const entries = Object.entries(serverEndpoints);
+
+  it('has at least 20 endpoints', () => {
+    expect(entries.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('every entry has a valid method, non-empty path starting with /, and non-empty description', () => {
+    for (const [key, entry] of entries) {
+      expect(
+        ['GET', 'POST', 'PUT', 'DELETE'],
+        `${key}: invalid method ${entry.method}`,
+      ).toContain(entry.method);
+      expect(entry.path.length, `${key}: empty path`).toBeGreaterThan(0);
+      expect(entry.path[0], `${key}: path does not start with /`).toBe('/');
+      expect(
+        entry.description.length,
+        `${key}: empty description`,
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -1,0 +1,278 @@
+/**
+ * Declarative endpoint catalog — single source of truth for the jeeves-server
+ * API surface. Consumers (CLI, OpenClaw plugin) derive their registrations
+ * from this catalog.
+ *
+ * @packageDocumentation
+ */
+
+import type { z } from 'zod';
+
+/**
+ * Describes a single API operation.
+ */
+export interface EndpointEntry {
+  /** HTTP method. */
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  /** URL path pattern (Fastify-style, e.g. '/api/file/*'). */
+  path: string;
+  /** Human-readable operation description. */
+  description: string;
+  /** Zod schema for query params (GET) or request body (POST/PUT). */
+  params?: z.ZodType;
+  /** Zod schema for the response body. */
+  response?: z.ZodType;
+  /** Whether the endpoint requires insider auth. */
+  insiderOnly?: boolean;
+  /** Whether the endpoint is unauthenticated. */
+  unauthenticated?: boolean;
+}
+
+/**
+ * Complete API endpoint catalog for jeeves-server.
+ *
+ * Keys are stable operation identifiers used by consumers to reference
+ * specific endpoints. Values describe the HTTP operation.
+ */
+export const serverEndpoints: Record<string, EndpointEntry> = {
+  // --- Status & Config ---
+  status: {
+    method: 'GET',
+    path: '/status',
+    description:
+      'Server health: name, version, uptime, status, health details.',
+    unauthenticated: true,
+  },
+  config: {
+    method: 'GET',
+    path: '/config',
+    description: 'Query running config with optional JSONPath filter (?path=).',
+    unauthenticated: true,
+  },
+  'config-apply': {
+    method: 'POST',
+    path: '/config/apply',
+    description:
+      'Push config patch to running service (deep-merge + validate + reload).',
+    insiderOnly: true,
+  },
+
+  // --- Authentication ---
+  'auth-status': {
+    method: 'GET',
+    path: '/api/auth/status',
+    description: 'Check current authentication status (no auth required).',
+    unauthenticated: true,
+  },
+  'auth-login': {
+    method: 'GET',
+    path: '/auth/login',
+    description: 'Redirect to Google OAuth consent screen.',
+    unauthenticated: true,
+  },
+  'auth-callback': {
+    method: 'GET',
+    path: '/auth/callback',
+    description: 'Handle Google OAuth callback, set session cookie.',
+    unauthenticated: true,
+  },
+  'auth-logout': {
+    method: 'GET',
+    path: '/auth/logout',
+    description: 'Clear session cookie.',
+    unauthenticated: true,
+  },
+
+  // --- File Browser ---
+  drives: {
+    method: 'GET',
+    path: '/api/drives',
+    description: 'List available root drives/labels configured on the server.',
+  },
+  path: {
+    method: 'GET',
+    path: '/api/path/*',
+    description: 'Get directory listing for a path.',
+  },
+  'file-get': {
+    method: 'GET',
+    path: '/api/file/*',
+    description:
+      'Get file content with type-specific handling (markdown, csv, diagrams, etc.).',
+  },
+  'file-put': {
+    method: 'PUT',
+    path: '/api/file/*',
+    description:
+      'Overwrite file content (insider-only; file must already exist).',
+    insiderOnly: true,
+  },
+  'file-mutate': {
+    method: 'POST',
+    path: '/api/file/*',
+    description:
+      'Apply structured .md mutations: edit-block, delete-block, insert-block, edit-cell, toggle-checkbox.',
+    insiderOnly: true,
+  },
+  raw: {
+    method: 'GET',
+    path: '/api/raw/*',
+    description: 'Direct file download with appropriate content type.',
+  },
+
+  // --- Export ---
+  export: {
+    method: 'GET',
+    path: '/api/export/*',
+    description: 'Trigger export (PDF, DOCX, ZIP) and return download.',
+  },
+  'export-cache-clear': {
+    method: 'DELETE',
+    path: '/api/export-cache/*',
+    description: 'Clear export and diagram caches for a given path.',
+    insiderOnly: true,
+  },
+  'mermaid-export': {
+    method: 'GET',
+    path: '/api/mermaid-export/*',
+    description: 'Export Mermaid diagram (svg, png, pdf).',
+  },
+  'plantuml-export': {
+    method: 'GET',
+    path: '/api/plantuml-export/*',
+    description: 'Export PlantUML diagram (svg, png, pdf, eps).',
+  },
+
+  // --- Diagrams ---
+  diagram: {
+    method: 'GET',
+    path: '/api/diagram/:type/:hash',
+    description: 'Fetch rendered diagram by type and content hash.',
+    unauthenticated: true,
+  },
+
+  // --- Sharing ---
+  share: {
+    method: 'POST',
+    path: '/api/share',
+    description: 'Generate HMAC-signed share link for a path.',
+    insiderOnly: true,
+  },
+  'share-for': {
+    method: 'POST',
+    path: '/api/util/share-for',
+    description:
+      'Generate share link targeting specific insiders with configurable expiry/depth.',
+    insiderOnly: true,
+  },
+  'readme-link': {
+    method: 'GET',
+    path: '/api/readme-link',
+    description:
+      'Pre-computed share link for the first README.md in the directory hierarchy.',
+    unauthenticated: true,
+  },
+  'content-link': {
+    method: 'GET',
+    path: '/api/content-link/:file',
+    description:
+      'Pre-computed deep share URL for pinned content files (privacy, terms).',
+    unauthenticated: true,
+  },
+  'link-info': {
+    method: 'GET',
+    path: '/api/link-info/*',
+    description:
+      'Query available link types for a path (page, raw, PDF, DOCX, etc.).',
+  },
+  'rotate-key': {
+    method: 'POST',
+    path: '/api/rotate-key',
+    description:
+      'Rotate the authenticated insider API key (invalidates all existing share links).',
+    insiderOnly: true,
+  },
+
+  // --- Events ---
+  event: {
+    method: 'POST',
+    path: '/event',
+    description: 'Event gateway webhook receiver (scoped key auth).',
+  },
+  events: {
+    method: 'GET',
+    path: '/api/events',
+    description: 'Query recent event log entries (limit capped at 100).',
+  },
+
+  // --- Search ---
+  search: {
+    method: 'POST',
+    path: '/api/search',
+    description: 'Semantic search (proxied to watcher).',
+  },
+  'search-facets': {
+    method: 'GET',
+    path: '/api/search/facets',
+    description: 'Search facet metadata (proxied to watcher).',
+  },
+
+  // --- Runner ---
+  runner: {
+    method: 'GET',
+    path: '/api/runner/*',
+    description: 'Runner API proxy (proxied to jeeves-runner).',
+  },
+
+  // --- OAuth ---
+  'oauth-start': {
+    method: 'POST',
+    path: '/api/oauth/start',
+    description: 'Initiate OAuth2 authorization code flow.',
+    insiderOnly: true,
+  },
+  'oauth-status': {
+    method: 'GET',
+    path: '/api/oauth/status',
+    description:
+      'Check if valid OAuth2 credentials exist for a provider/account.',
+    insiderOnly: true,
+  },
+  'oauth-token': {
+    method: 'GET',
+    path: '/api/oauth/token',
+    description: 'Retrieve valid access token (with lazy refresh).',
+    insiderOnly: true,
+  },
+  'oauth-callback': {
+    method: 'GET',
+    path: '/oauth/callback',
+    description: 'OAuth2 callback (browser redirect target, unauthenticated).',
+    unauthenticated: true,
+  },
+
+  // --- Keys ---
+  'insider-key': {
+    method: 'GET',
+    path: '/insider-key',
+    description: 'Get insider key for the authenticated user.',
+  },
+  key: {
+    method: 'GET',
+    path: '/key',
+    description: 'Compute path-specific key.',
+  },
+  'share-legacy': {
+    method: 'GET',
+    path: '/share',
+    description: 'Generate outsider share link (top-level legacy route).',
+  },
+
+  // --- Shortlinks ---
+  go: {
+    method: 'GET',
+    path: '/go/:slug',
+    description: 'Shortlink redirect (unauthenticated).',
+    unauthenticated: true,
+  },
+} as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,8 @@ export {
   type JeevesConfig,
   jeevesConfigSchema,
   keyEntrySchema,
+  type LoggingConfig,
+  loggingConfigSchema,
   oauthProviderSchema,
   oauthSchema,
   scopesObjectSchema,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export {
   type DeepShareParams,
   timingSafeEqual,
 } from './crypto.js';
+export { type EndpointEntry, serverEndpoints } from './endpoints.js';
 export {
   type AuthMode,
   authModeSchema,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -112,6 +112,23 @@ function getScopeRefs(scopes: unknown): string[] {
   return [];
 }
 
+/** Logging configuration. Not hot-reloadable — changes require service restart. */
+export const loggingConfigSchema = z.object({
+  /** Log level. */
+  level: z
+    .string()
+    .optional()
+    .describe('Logging level (trace, debug, info, warn, error, fatal).'),
+  /** Log file path. */
+  file: z
+    .string()
+    .optional()
+    .describe('Path to log file (logs to stdout if omitted).'),
+});
+
+/** Inferred logging config type. */
+export type LoggingConfig = z.infer<typeof loggingConfigSchema>;
+
 /** OAuth provider configuration */
 export const oauthProviderSchema = z.object({
   authUrl: z.string().pipe(z.url()),
@@ -176,6 +193,11 @@ export const jeevesConfigSchema = z
      * If omitted, all paths are shareable with outsiders.
      */
     outsiderPolicy: scopesSchema.optional(),
+    /**
+     * Logging configuration.
+     * Not hot-reloadable — changes require a service restart.
+     */
+    logging: loggingConfigSchema.optional(),
     /** OAuth2 credential management configuration */
     oauth: oauthSchema.optional(),
     /**

--- a/packages/openclaw/skills/jeeves-server/SKILL.md
+++ b/packages/openclaw/skills/jeeves-server/SKILL.md
@@ -15,6 +15,15 @@ Operate and interact with a jeeves-server deployment. Use for file browsing, doc
 | `server_config` | Query resolved server configuration (supports JSONPath) |
 | `server_config_apply` | Apply a configuration patch to the running server |
 | `server_service` | Manage the system service (install, uninstall, start, stop, restart, status) |
+| `server_file_write` | Overwrite file content (insider-only; file must already exist) |
+| `server_file_mutate` | Apply structured .md mutations: edit-block, delete-block, insert-block, edit-cell, toggle-checkbox |
+| `server_rotate_key` | Rotate the authenticated insider's API key (invalidates all share links) |
+| `server_export_cache_clear` | Clear export and diagram caches for a given path |
+| `server_drives` | List available root drives/labels configured on the server |
+| `server_auth_status` | Check current authentication status |
+| `oauth_authorize` | Initiate OAuth2 authorization for a provider/account |
+| `oauth_status` | Check if valid OAuth2 credentials exist for a provider/account |
+| `oauth_token` | Retrieve a valid access token (with automatic refresh) |
 
 ## Browse Paths
 
@@ -28,9 +37,19 @@ To convert a Windows file path to a browse path:
 
 When the `publicUrl` plugin config is set (e.g. `https://jeeves.example.com`), all URLs returned by server tools are automatically rewritten to use the public domain instead of the internal `apiUrl`. No manual URL rewriting is needed.
 
-## Checkbox Toggling
+## Inline Editing
 
-Insiders can toggle GFM task-list checkboxes in rendered Markdown pages via the web UI. The server exposes `POST /api/toggle-checkbox/*` with stale-write protection (mtime-based conflict detection). This is a web-UI feature — no agent tool is required.
+Insiders can edit rendered Markdown pages via the web UI:
+- **Block editing:** Hover controls on rendered blocks (paragraphs, headings, lists, tables, code, diagrams) for edit, copy, insert, and delete
+- **Cell editing:** Direct table cell editing
+- **Checkbox toggling:** Interactive task-list checkboxes via `POST /api/file/*` with `action: 'toggle-checkbox'` (fire-and-forget, last-write-wins)
+- **Full-document editing:** Edit button in the tab bar (visible on both rendered and raw tabs for insiders)
+
+All mutations go through `POST /api/file/*` (unified mutation endpoint). The `server_file_mutate` tool provides agent access to the same mutations.
+
+## Auth Gate
+
+Unauthenticated browser access to SPA routes (`/`, `/browse/*`, `/runner/*`) returns a branded sign-in page instead of the SPA. The page shows a "Sign in with Google" button (when Google auth is configured) or an API key required message. After sign-in, the user is redirected back to the originally requested page. API routes continue returning JSON 401 for programmatic clients.
 
 ## Browse Features
 
@@ -120,6 +139,9 @@ Or create `jeeves-server/config.json` manually (JSON only):
     "_internal": "random-hex-seed-for-puppeteer",
     "_plugin": "random-hex-seed-for-openclaw-plugin",
     "primary": "random-hex-seed-for-api-access"
+  },
+  "logging": {
+    "level": "info"
   }
 }
 ```

--- a/packages/service/client/src/components/TabBar.tsx
+++ b/packages/service/client/src/components/TabBar.tsx
@@ -86,9 +86,9 @@ export function TabBar({
         </div>
       )}
       {undoRedoControls}
-      {isInsider && activeTab === 'raw' && file?.content != null && !editing && (
+      {isInsider && file?.content != null && !editing && (
         <button
-          onClick={() => setEditing(true)}
+          onClick={() => { if (activeTab !== 'raw') setViewTab('raw'); setEditing(true); }}
           className="ml-2 flex items-center gap-1 px-2 py-1 text-sm text-muted-foreground hover:text-foreground border border-border rounded transition-colors"
           title="Edit file"
         >

--- a/packages/service/guides/api-integration.md
+++ b/packages/service/guides/api-integration.md
@@ -12,7 +12,7 @@ All API requests (except `/health` and `/api/status`) authenticate via `?key=<in
 
 ### Browser Auth Gate
 
-When an unauthenticated browser hits a SPA route (`/browse/*`, `/runner/*`), the server returns a branded sign-in page instead of the SPA. The page offers a "Sign in with Google" button (when Google OAuth is configured) or an API key required message (keys-only mode). After successful Google sign-in, the user is redirected back to the originally requested page.
+When an unauthenticated browser hits a SPA route (`/`, `/browse/*`, `/runner/*`), the server returns a branded sign-in page instead of the SPA. The page offers a "Sign in with Google" button (when Google OAuth is configured) or an API key required message (keys-only mode). After successful Google sign-in, the user is redirected back to the originally requested page.
 
 API routes continue returning JSON `{ error: 'Unauthorized' }` for programmatic clients — the sign-in page only applies to browser-navigated SPA paths.
 

--- a/packages/service/guides/api-integration.md
+++ b/packages/service/guides/api-integration.md
@@ -10,6 +10,12 @@ How to interact with Jeeves Server programmatically — for scripts, bots, AI as
 
 All API requests (except `/health` and `/api/status`) authenticate via `?key=<insider-key>` URL parameter or session cookie.
 
+### Browser Auth Gate
+
+When an unauthenticated browser hits a SPA route (`/browse/*`, `/runner/*`), the server returns a branded sign-in page instead of the SPA. The page offers a "Sign in with Google" button (when Google OAuth is configured) or an API key required message (keys-only mode). After successful Google sign-in, the user is redirected back to the originally requested page.
+
+API routes continue returning JSON `{ error: 'Unauthorized' }` for programmatic clients — the sign-in page only applies to browser-navigated SPA paths.
+
 ```json
 {
   "keys": {

--- a/packages/service/guides/setup.md
+++ b/packages/service/guides/setup.md
@@ -68,6 +68,28 @@ Legacy paths (`jeeves-server.config.json`) are auto-migrated to the new conventi
 }
 ```
 
+### Logging
+
+Optional logging configuration. Matches the pattern used by jeeves-watcher and jeeves-meta.
+
+```json
+{
+  "logging": {
+    "level": "debug",
+    "file": "/var/log/jeeves-server.log"
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `level` | string | `info` | Pino log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
+| `file` | string | — | Log file path. When set, logs are written to this file via pino file transport. When omitted, logs go to stdout. |
+
+The entire `logging` block is optional. When absent, the server uses pino's default (`info` level, stdout).
+
+> **Not hot-reloadable.** Logging config is set when the Fastify server is constructed. Changes require `jeeves-server service restart`.
+
 ### Environment variable substitution
 
 String values in the config support `${VAR_NAME}` substitution from `process.env`:

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -20,12 +20,12 @@
     "markdown-it-anchor": "^9.2.0",
     "markdown-it-task-lists": "^2.1.1",
     "mime-types": "^3.0.2",
-    "package-directory": "^8.2.0",
     "picomatch": "^4.0.4",
     "plantuml-encoder": "^1.4.0",
     "puppeteer": "^24.43.1",
     "puppeteer-core": "^23.11.1",
-    "radash": "^12.1.1"
+    "radash": "^12.1.1",
+    "zod": "^4.4.3"
   },
   "description": "Secure file browser, markdown viewer, and webhook gateway with PDF/DOCX export and expiring share links",
   "devDependencies": {

--- a/packages/service/src/auth/resolve.test.ts
+++ b/packages/service/src/auth/resolve.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractDeepParams, sanitizeReturnTo } from './resolve.js';
+
+describe('extractDeepParams', () => {
+  it('returns undefined when d is absent', () => {
+    expect(extractDeepParams({ s: 'stack' })).toBeUndefined();
+  });
+
+  it('returns undefined when s is absent', () => {
+    expect(extractDeepParams({ d: '2' })).toBeUndefined();
+  });
+
+  it('returns undefined when both d and s are absent', () => {
+    expect(extractDeepParams({})).toBeUndefined();
+  });
+
+  it('extracts params when d and s are present', () => {
+    expect(extractDeepParams({ d: '2', s: 'abc' })).toEqual({
+      d: '2',
+      dirs: '0',
+      s: 'abc',
+    });
+  });
+
+  it('passes dirs through when present', () => {
+    expect(extractDeepParams({ d: '1', dirs: '1', s: 'xyz' })).toEqual({
+      d: '1',
+      dirs: '1',
+      s: 'xyz',
+    });
+  });
+
+  it('defaults dirs to 0 when absent', () => {
+    const result = extractDeepParams({ d: '3', s: 'stack' });
+    expect(result?.dirs).toBe('0');
+  });
+
+  it('ignores key and exp fields', () => {
+    const result = extractDeepParams({
+      key: 'abc',
+      exp: '123',
+      d: '1',
+      s: 's',
+    });
+    expect(result).toEqual({ d: '1', dirs: '0', s: 's' });
+  });
+});
+
+describe('sanitizeReturnTo', () => {
+  it('allows a simple relative path', () => {
+    expect(sanitizeReturnTo('/browse/j/docs')).toBe('/browse/j/docs');
+  });
+
+  it('allows root path', () => {
+    expect(sanitizeReturnTo('/')).toBe('/');
+  });
+
+  it('allows path with query string', () => {
+    expect(sanitizeReturnTo('/browse?key=abc')).toBe('/browse?key=abc');
+  });
+
+  it('rejects protocol-relative URLs', () => {
+    expect(sanitizeReturnTo('//evil.com')).toBe('/browse');
+  });
+
+  it('rejects absolute http URLs', () => {
+    expect(sanitizeReturnTo('https://evil.com')).toBe('/browse');
+  });
+
+  it('rejects javascript: URIs', () => {
+    expect(sanitizeReturnTo('javascript:alert(1)')).toBe('/browse');
+  });
+
+  it('rejects data: URIs', () => {
+    expect(sanitizeReturnTo('data:text/html,<h1>hi</h1>')).toBe('/browse');
+  });
+
+  it('rejects bare strings', () => {
+    expect(sanitizeReturnTo('evil.com/path')).toBe('/browse');
+  });
+
+  it('uses custom fallback when provided', () => {
+    expect(sanitizeReturnTo('https://evil.com', '/home')).toBe('/home');
+  });
+});

--- a/packages/service/src/auth/resolve.ts
+++ b/packages/service/src/auth/resolve.ts
@@ -168,6 +168,15 @@ export function extractDeepParams(
 }
 
 /**
+ * Validate a returnTo redirect target for open-redirect safety.
+ * Only allows relative paths starting with a single /.
+ * Returns the fallback value for anything else.
+ */
+export function sanitizeReturnTo(raw: string, fallback = '/browse'): string {
+  return raw.startsWith('/') && !raw.startsWith('//') ? raw : fallback;
+}
+
+/**
  * Find a resolved insider by email.
  */
 export function findInsider(

--- a/packages/service/src/auth/resolve.ts
+++ b/packages/service/src/auth/resolve.ts
@@ -146,6 +146,27 @@ export function resolveSessionAuth(
   };
 }
 
+/** Query params used for auth resolution on SPA and API routes. */
+export interface AuthQuery {
+  key?: string;
+  exp?: string;
+  d?: string;
+  dirs?: string;
+  s?: string;
+}
+
+/**
+ * Extract deep share params from a parsed query object.
+ * Returns undefined when no deep share context is present.
+ */
+export function extractDeepParams(
+  query: AuthQuery,
+): { d: string; dirs: string; s: string } | undefined {
+  return query.d !== undefined && query.s !== undefined
+    ? { d: query.d, dirs: query.dirs ?? '0', s: query.s }
+    : undefined;
+}
+
 /**
  * Find a resolved insider by email.
  */

--- a/packages/service/src/auth/signInPage.test.ts
+++ b/packages/service/src/auth/signInPage.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderSignInPage } from './signInPage.js';
+
+describe('renderSignInPage', () => {
+  it('includes the page title', () => {
+    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
+    expect(html).toContain('<title>Jeeves Server');
+  });
+
+  it('includes the sign-in heading', () => {
+    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
+    expect(html).toContain('Sign in to continue');
+  });
+
+  it('shows the requested path', () => {
+    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
+    expect(html).toContain('/browse/j/docs/readme.md');
+  });
+
+  it('renders a Google sign-in link when google mode is active', () => {
+    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
+    expect(html).toContain('/auth/login?returnTo=');
+    expect(html).toContain('Sign in with Google');
+  });
+
+  it('encodes the returnTo URL', () => {
+    const html = renderSignInPage('/browse/j/docs/readme.md?foo=bar', [
+      'google',
+    ]);
+    expect(html).toContain(
+      encodeURIComponent('/browse/j/docs/readme.md?foo=bar'),
+    );
+  });
+
+  it('shows key-required message when google mode is absent', () => {
+    const html = renderSignInPage('/browse/j/docs/readme.md', ['keys']);
+    expect(html).toContain('API key for access');
+    expect(html).not.toContain('Sign in with Google');
+  });
+
+  it('includes dark mode media query', () => {
+    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
+    expect(html).toContain('prefers-color-scheme: dark');
+  });
+
+  it('escapes HTML entities in the URL', () => {
+    const html = renderSignInPage('/browse/<script>alert(1)</script>', [
+      'google',
+    ]);
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/packages/service/src/auth/signInPage.test.ts
+++ b/packages/service/src/auth/signInPage.test.ts
@@ -3,48 +3,32 @@ import { describe, expect, it } from 'vitest';
 import { renderSignInPage } from './signInPage.js';
 
 describe('renderSignInPage', () => {
-  it('includes the page title', () => {
+  it('renders valid HTML with title, heading, path context, and dark mode support', () => {
     const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
     expect(html).toContain('<title>Jeeves Server');
-  });
-
-  it('includes the sign-in heading', () => {
-    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
     expect(html).toContain('Sign in to continue');
-  });
-
-  it('shows the requested path', () => {
-    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
     expect(html).toContain('/browse/j/docs/readme.md');
+    expect(html).toContain('prefers-color-scheme: dark');
   });
 
-  it('renders a Google sign-in link when google mode is active', () => {
-    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
-    expect(html).toContain('/auth/login?returnTo=');
-    expect(html).toContain('Sign in with Google');
-  });
-
-  it('encodes the returnTo URL', () => {
+  it('renders Google sign-in link with encoded returnTo when google mode is active', () => {
     const html = renderSignInPage('/browse/j/docs/readme.md?foo=bar', [
       'google',
     ]);
+    expect(html).toContain('/auth/login?returnTo=');
+    expect(html).toContain('Sign in with Google');
     expect(html).toContain(
       encodeURIComponent('/browse/j/docs/readme.md?foo=bar'),
     );
   });
 
-  it('shows key-required message when google mode is absent', () => {
+  it('shows key-required message without Google link when google mode is absent', () => {
     const html = renderSignInPage('/browse/j/docs/readme.md', ['keys']);
     expect(html).toContain('API key for access');
     expect(html).not.toContain('Sign in with Google');
   });
 
-  it('includes dark mode media query', () => {
-    const html = renderSignInPage('/browse/j/docs/readme.md', ['google']);
-    expect(html).toContain('prefers-color-scheme: dark');
-  });
-
-  it('escapes HTML entities in the URL', () => {
+  it('escapes HTML entities in the URL to prevent XSS', () => {
     const html = renderSignInPage('/browse/<script>alert(1)</script>', [
       'google',
     ]);

--- a/packages/service/src/auth/signInPage.ts
+++ b/packages/service/src/auth/signInPage.ts
@@ -1,0 +1,84 @@
+/**
+ * Server-rendered sign-in page for unauthenticated SPA requests.
+ *
+ * Uses the same minimal inline HTML pattern as the OAuth callback pages.
+ * No SPA dependencies, no CSS framework.
+ *
+ * @packageDocumentation
+ */
+
+import type { AuthMode } from '../config/types.js';
+
+/**
+ * Render a branded sign-in page HTML string.
+ *
+ * @param requestUrl - The URL the user was trying to access.
+ * @param authModes - Configured auth modes from the server config.
+ * @returns Complete HTML page string.
+ */
+export function renderSignInPage(
+  requestUrl: string,
+  authModes: AuthMode[],
+): string {
+  const escapedUrl = escapeHtml(requestUrl);
+  const hasGoogle = authModes.includes('google');
+  const loginHref = `/auth/login?returnTo=${encodeURIComponent(requestUrl)}`;
+
+  const actionHtml = hasGoogle
+    ? `<a href="${escapeHtml(loginHref)}" style="display:inline-block;padding:10px 24px;background:#4285f4;color:#fff;text-decoration:none;border-radius:4px;font-size:14px;font-weight:500;">Sign in with Google</a>`
+    : `<p style="color:#888;">This server requires an API key for access.</p>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Jeeves Server — Sign In</title>
+<style>
+  body {
+    font-family: system-ui, -apple-system, sans-serif;
+    max-width: 480px;
+    margin: 80px auto;
+    padding: 0 20px;
+    text-align: center;
+    color: #1a1a1a;
+    background: #fff;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e0e0e0; background: #1a1a1a; }
+    code { background: #2a2a2a; }
+    a[href] { background: #4285f4; }
+  }
+  h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; }
+  p { font-size: 0.95rem; line-height: 1.5; color: #666; }
+  @media (prefers-color-scheme: dark) { p { color: #999; } }
+  code {
+    display: inline-block;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-all;
+    padding: 2px 6px;
+    background: #f0f0f0;
+    border-radius: 3px;
+    font-size: 0.85rem;
+  }
+  .action { margin-top: 2rem; }
+</style>
+</head>
+<body>
+<h1>Sign in to continue</h1>
+<p>You're trying to access:<br><code>${escapedUrl}</code></p>
+<div class="action">${actionHtml}</div>
+</body>
+</html>`;
+}
+
+/** Basic HTML entity escaping for untrusted values. */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -262,7 +262,7 @@ export function buildRuntimeConfig(
           providers: config.oauth.providers,
         }
       : null,
-    logging: config.logging ?? undefined,
+    logging: config.logging,
     go: config.go,
     configPath,
     eventsLog: path.join(rootDir, 'logs', 'webhook-events.jsonl'),

--- a/packages/service/src/config/resolve.ts
+++ b/packages/service/src/config/resolve.ts
@@ -262,6 +262,7 @@ export function buildRuntimeConfig(
           providers: config.oauth.providers,
         }
       : null,
+    logging: config.logging ?? undefined,
     go: config.go,
     configPath,
     eventsLog: path.join(rootDir, 'logs', 'webhook-events.jsonl'),

--- a/packages/service/src/config/schema.ts
+++ b/packages/service/src/config/schema.ts
@@ -10,6 +10,8 @@ export {
   type JeevesConfig,
   jeevesConfigSchema,
   keyEntrySchema,
+  type LoggingConfig,
+  loggingConfigSchema,
   oauthProviderSchema,
   oauthSchema,
   scopesObjectSchema,

--- a/packages/service/src/config/types.ts
+++ b/packages/service/src/config/types.ts
@@ -3,10 +3,10 @@
  * Config types are derived from Zod schema in schema.ts.
  */
 
-import type { AuthMode, JeevesConfig } from './schema.js';
+import type { AuthMode, JeevesConfig, LoggingConfig } from './schema.js';
 
 // Re-export config types from schema
-export type { AuthMode, JeevesConfig };
+export type { AuthMode, JeevesConfig, LoggingConfig };
 
 /**
  * Normalized scopes — always resolved to \{ allow, deny \} form.
@@ -82,6 +82,8 @@ export interface RuntimeConfig {
       }
     >;
   } | null;
+  /** Logging configuration (not hot-reloadable). */
+  logging?: LoggingConfig;
   /** Shortlink slug → redirect target map. */
   go: Record<string, string>;
   configPath: string;

--- a/packages/service/src/routes/api/middleware.ts
+++ b/packages/service/src/routes/api/middleware.ts
@@ -5,6 +5,8 @@
 import type { FastifyInstance } from 'fastify';
 
 import {
+  type AuthQuery,
+  extractDeepParams,
   resolveInsiderKeyAuth,
   resolveKeyAuth,
   resolveSessionAuth,
@@ -70,17 +72,8 @@ export function addAuthMiddleware(fastify: FastifyInstance): void {
     }
 
     // General API auth
-    const query = request.query as {
-      key?: string;
-      exp?: string;
-      d?: string;
-      dirs?: string;
-      s?: string;
-    };
-    const deepParams =
-      query.d !== undefined && query.s !== undefined
-        ? { d: query.d, dirs: query.dirs ?? '0', s: query.s }
-        : undefined;
+    const query = request.query as AuthQuery;
+    const deepParams = extractDeepParams(query);
 
     const urlPath = request.url
       .split('?')[0]

--- a/packages/service/src/routes/auth.ts
+++ b/packages/service/src/routes/auth.ts
@@ -11,6 +11,7 @@ import crypto from 'node:crypto';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { buildAuthUrl, exchangeCode, getUserInfo } from '../auth/google.js';
+import { sanitizeReturnTo } from '../auth/resolve.js';
 import { COOKIE_NAME, createSessionCookie } from '../auth/session.js';
 import { getConfig, resetConfig } from '../config/index.js';
 import { writeInsiderSeedToConfig } from '../util/configPersist.js';
@@ -130,12 +131,7 @@ export const authRoute: FastifyPluginAsync = async (fastify) => {
     const rawReturnTo = request.query.state
       ? Buffer.from(request.query.state, 'base64url').toString()
       : '/browse';
-    // Only allow relative paths starting with a single / (blocks protocol-relative
-    // URLs like //evil.com, scheme URLs like javascript:..., and CRLF injection)
-    const returnTo =
-      rawReturnTo.startsWith('/') && !rawReturnTo.startsWith('//')
-        ? rawReturnTo
-        : '/browse';
+    const returnTo = sanitizeReturnTo(rawReturnTo);
     return reply.redirect(returnTo);
   });
 

--- a/packages/service/src/routes/auth.ts
+++ b/packages/service/src/routes/auth.ts
@@ -130,10 +130,12 @@ export const authRoute: FastifyPluginAsync = async (fastify) => {
     const rawReturnTo = request.query.state
       ? Buffer.from(request.query.state, 'base64url').toString()
       : '/browse';
-    // Reject absolute URLs to prevent open redirect
-    const returnTo = /^[a-z]+:\/\//i.test(rawReturnTo)
-      ? '/browse'
-      : rawReturnTo;
+    // Only allow relative paths starting with a single / (blocks protocol-relative
+    // URLs like //evil.com, scheme URLs like javascript:..., and CRLF injection)
+    const returnTo =
+      rawReturnTo.startsWith('/') && !rawReturnTo.startsWith('//')
+        ? rawReturnTo
+        : '/browse';
     return reply.redirect(returnTo);
   });
 

--- a/packages/service/src/routes/auth.ts
+++ b/packages/service/src/routes/auth.ts
@@ -126,10 +126,14 @@ export const authRoute: FastifyPluginAsync = async (fastify) => {
       maxAge: 30 * 24 * 60 * 60, // 30 days in seconds
     });
 
-    // Redirect to returnTo or root
-    const returnTo = request.query.state
+    // Redirect to returnTo or root (with open-redirect protection)
+    const rawReturnTo = request.query.state
       ? Buffer.from(request.query.state, 'base64url').toString()
       : '/browse';
+    // Reject absolute URLs to prevent open redirect
+    const returnTo = /^[a-z]+:\/\//i.test(rawReturnTo)
+      ? '/browse'
+      : rawReturnTo;
     return reply.redirect(returnTo);
   });
 

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -12,6 +12,8 @@ import fastifyStatic from '@fastify/static';
 import { getBindAddress } from '@karmaniverous/jeeves';
 import Fastify, { type FastifyReply, type FastifyRequest } from 'fastify';
 
+import { resolveKeyAuth, resolveSessionAuth } from './auth/resolve.js';
+import { renderSignInPage } from './auth/signInPage.js';
 import { getConfig, initConfig, isConfigInitialized } from './config/index.js';
 import { apiRoute } from './routes/api/index.js';
 import { authRoute } from './routes/auth.js';
@@ -85,11 +87,51 @@ async function start() {
         prefix: '/app/',
       });
 
-      // SPA fallback — all these routes serve index.html for client-side routing
+      // Auth-gated SPA fallback — serves index.html for authenticated users,
+      // branded sign-in page for unauthenticated users (#214)
       const spaFallback = async (
-        _request: FastifyRequest,
+        request: FastifyRequest,
         reply: FastifyReply,
-      ) => reply.sendFile('index.html', clientDir);
+      ) => {
+        const cfg = getConfig();
+        const query = request.query as {
+          key?: string;
+          exp?: string;
+          d?: string;
+          dirs?: string;
+          s?: string;
+        };
+
+        // Extract the browse path from the URL for path-scoped key verification.
+        // /browse/j/docs/readme.md → j/docs/readme.md
+        const urlPath =
+          request.url
+            .split('?')[0]
+            .replace(/^\/browse\//, '')
+            .replace(/^\/runner\//, '') || '/';
+
+        const deepParams =
+          query.d !== undefined && query.s !== undefined
+            ? { d: query.d, dirs: query.dirs ?? '0', s: query.s }
+            : undefined;
+        const keyResult = resolveKeyAuth(
+          cfg,
+          urlPath,
+          query.key,
+          query.exp,
+          deepParams,
+        );
+        const sessionResult = resolveSessionAuth(cfg, request);
+
+        if (keyResult.valid || sessionResult.valid) {
+          return reply.sendFile('index.html', clientDir);
+        }
+
+        return reply
+          .type('text/html')
+          .code(401)
+          .send(renderSignInPage(request.url, cfg.authModes));
+      };
 
       for (const route of [
         '/',
@@ -109,7 +151,7 @@ async function start() {
           (request.url.startsWith('/browse') ||
             request.url.startsWith('/runner'))
         ) {
-          return reply.sendFile('index.html', clientDir);
+          return spaFallback(request, reply);
         }
         return reply.code(404).send({ error: 'Not found' });
       });

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -104,11 +104,10 @@ async function start() {
 
         // Extract the browse path from the URL for path-scoped key verification.
         // /browse/j/docs/readme.md → j/docs/readme.md
+        // /browse or /browse/ → /
         const urlPath =
-          request.url
-            .split('?')[0]
-            .replace(/^\/browse\//, '')
-            .replace(/^\/runner\//, '') || '/';
+          request.url.split('?')[0].replace(/^\/(browse|runner)(\/|$)/, '') ||
+          '/';
 
         const deepParams =
           query.d !== undefined && query.s !== undefined

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -12,7 +12,12 @@ import fastifyStatic from '@fastify/static';
 import { getBindAddress } from '@karmaniverous/jeeves';
 import Fastify, { type FastifyReply, type FastifyRequest } from 'fastify';
 
-import { resolveKeyAuth, resolveSessionAuth } from './auth/resolve.js';
+import {
+  type AuthQuery,
+  extractDeepParams,
+  resolveKeyAuth,
+  resolveSessionAuth,
+} from './auth/resolve.js';
 import { renderSignInPage } from './auth/signInPage.js';
 import { getConfig, initConfig, isConfigInitialized } from './config/index.js';
 import { apiRoute } from './routes/api/index.js';
@@ -94,13 +99,7 @@ async function start() {
         reply: FastifyReply,
       ) => {
         const cfg = getConfig();
-        const query = request.query as {
-          key?: string;
-          exp?: string;
-          d?: string;
-          dirs?: string;
-          s?: string;
-        };
+        const query = request.query as AuthQuery;
 
         // Extract the browse path from the URL for path-scoped key verification.
         // /browse/j/docs/readme.md → j/docs/readme.md
@@ -109,16 +108,12 @@ async function start() {
           request.url.split('?')[0].replace(/^\/(browse|runner)(\/|$)/, '') ||
           '/';
 
-        const deepParams =
-          query.d !== undefined && query.s !== undefined
-            ? { d: query.d, dirs: query.dirs ?? '0', s: query.s }
-            : undefined;
         const keyResult = resolveKeyAuth(
           cfg,
           urlPath,
           query.key,
           query.exp,
-          deepParams,
+          extractDeepParams(query),
         );
         const sessionResult = resolveSessionAuth(cfg, request);
 

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -33,8 +33,19 @@ async function start() {
   try {
     const config = isConfigInitialized() ? getConfig() : initConfig();
 
+    // Logging config (not hot-reloadable — requires service restart)
+    const loggerConfig: Record<string, unknown> = {
+      level: config.logging?.level ?? 'info',
+    };
+    if (config.logging?.file) {
+      loggerConfig.transport = {
+        target: 'pino/file',
+        options: { destination: config.logging.file, mkdir: true },
+      };
+    }
+
     const fastify = Fastify({
-      logger: true,
+      logger: loggerConfig,
     });
 
     // Register plugins


### PR DESCRIPTION
Closes #210, closes #211, closes #213, closes #214

## Next Version Release

Five changes from the dev plan, executed in dependency order:

### 1. Dependency hygiene
- Add `zod` as direct dependency (was transitive via core; 80+ source files import it)
- Remove stale `package-directory` dep (unused since `packageVersion.ts` refactor)

### 2. #211 — Edit link on rendered tab
- `TabBar.tsx`: remove `activeTab === 'raw'` guard on the Edit button
- When clicked from rendered tab, switches to raw tab + enables editing in one action

### 3. #213 — Logging configuration
- Core: add `loggingConfigSchema` (matches watcher pattern — `level` and `file`, both optional)
- Service: wire into Fastify constructor (`pino/file` transport when `logging.file` is set)
- Not hot-reloadable (requires service restart, same as watcher/meta)

### 4. #214 — Friendly auth gate
- New `src/auth/signInPage.ts` — server-rendered sign-in page (dark/light, Google button or keys-only message)
- Auth-gated SPA fallback in `server.ts` — checks key + session before serving `index.html`; path-scoped outsider keys and deep share links resolve correctly
- Security fix: open-redirect validation on `returnTo` in `/auth/callback`

### 5. #210 — Endpoint catalog
- New `packages/core/src/endpoints.ts` — 37-endpoint declarative catalog covering the full API surface
- Purely declarative (no Fastify dependency); consumer migration deferred to future release
- CI test verifies every entry has valid method, path, and description

## Verification

- Core: build, lint, typecheck, 2 tests passing
- Service: build (server + client), lint, typecheck, 309 tests passing
