### PR TITLE
fix: show edit button on rendered tab for insiders (#211)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14667,7 +14667,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-server-openclaw",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.12",
@@ -14695,7 +14695,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-server",
-      "version": "3.10.13",
+      "version": "3.10.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -14715,12 +14715,12 @@
         "markdown-it-anchor": "^9.2.0",
         "markdown-it-task-lists": "^2.1.1",
         "mime-types": "^3.0.2",
-        "package-directory": "^8.2.0",
         "picomatch": "^4.0.4",
         "plantuml-encoder": "^1.4.0",
         "puppeteer": "^24.43.1",
         "puppeteer-core": "^23.11.1",
-        "radash": "^12.1.1"
+        "radash": "^12.1.1",
+        "zod": "^4.4.3"
       },
       "bin": {
         "jeeves-server": "dist/src/cli/index.js"

--- a/packages/service/client/src/components/TabBar.tsx
+++ b/packages/service/client/src/components/TabBar.tsx
@@ -86,9 +86,9 @@ export function TabBar({
         </div>
       )}
       {undoRedoControls}
-      {isInsider && activeTab === 'raw' && file?.content != null && !editing && (
+      {isInsider && file?.content != null && !editing && (
         <button
-          onClick={() => setEditing(true)}
+          onClick={() => { if (activeTab !== 'raw') setViewTab('raw'); setEditing(true); }}
           className="ml-2 flex items-center gap-1 px-2 py-1 text-sm text-muted-foreground hover:text-foreground border border-border rounded transition-colors"
           title="Edit file"
         >

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -20,12 +20,12 @@
     "markdown-it-anchor": "^9.2.0",
     "markdown-it-task-lists": "^2.1.1",
     "mime-types": "^3.0.2",
-    "package-directory": "^8.2.0",
     "picomatch": "^4.0.4",
     "plantuml-encoder": "^1.4.0",
     "puppeteer": "^24.43.1",
     "puppeteer-core": "^23.11.1",
-    "radash": "^12.1.1"
+    "radash": "^12.1.1",
+    "zod": "^4.4.3"
   },
   "description": "Secure file browser, markdown viewer, and webhook gateway with PDF/DOCX export and expiring share links",
   "devDependencies": {


### PR DESCRIPTION
Closes #211

## Problem

The full-document Edit button in \TabBar.tsx\ was only visible when \ctiveTab === 'raw'\. Insiders viewing the rendered tab had to manually switch to Raw first.

## Fix

Remove the \ctiveTab === 'raw'\ guard. When clicked from the rendered tab, the handler switches to raw tab and enables editing in one action.

## Verification

- Build: clean
- Lint: clean
- Typecheck: clean