### PR TITLE
fix: effective auth modes gate + lint cleanup

### DIFF
--- a/packages/service/src/config/types.ts
+++ b/packages/service/src/config/types.ts
@@ -109,6 +109,24 @@ export interface RuntimeConfig {
 }
 
 /**
+ * Compute effective auth modes — only those with complete configuration.
+ * Filters out modes where required config is missing.
+ */
+export function getEffectiveAuthModes(config: RuntimeConfig): AuthMode[] {
+  return config.authModes.filter((mode) => {
+    if (mode === 'google')
+      return config.googleAuth !== null && config.sessionSecret !== null;
+    if (mode === 'email')
+      return (
+        config.emailAuth !== null &&
+        config.emailAuth !== undefined &&
+        config.sessionSecret !== null
+      );
+    return true; // 'keys' is always available if listed
+  });
+}
+
+/**
  * Access mode for authenticated requests
  */
 export type AccessMode = 'insider' | 'outsider';

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -20,6 +20,7 @@ import {
 } from './auth/resolve.js';
 import { renderSignInPage } from './auth/signInPage.js';
 import { getConfig, initConfig, isConfigInitialized } from './config/index.js';
+import { getEffectiveAuthModes } from './config/types.js';
 import { apiRoute } from './routes/api/index.js';
 import { authRoute } from './routes/auth.js';
 import { registerConfigRoute } from './routes/config.js';
@@ -127,7 +128,13 @@ async function start() {
         return reply
           .type('text/html')
           .code(401)
-          .send(renderSignInPage(request.url, cfg.authModes, cfg.branding));
+          .send(
+            renderSignInPage(
+              request.url,
+              getEffectiveAuthModes(cfg),
+              cfg.branding,
+            ),
+          );
       };
 
       for (const route of [


### PR DESCRIPTION
Post-merge follow-up to PR #232.

- **Effective auth modes gate:** Sign-in page now uses `getEffectiveAuthModes(config)` to filter `auth.modes` to only those with complete backing configuration. Google button won't render unless `googleAuth` + `sessionSecret` are both present; email form won't render unless `emailAuth` + `sessionSecret` are present.
- **Lint fixes:** Prettier formatting, deprecated `z.string().email()` to `z.email()`, unnecessary optional chains, async arrow functions without await in test mocks.
- **Stale doc references:** Fixed 7 remaining stale auth references across setup.md, SKILL.md, and api-integration.md.
