### PR TITLE
fix: SPA sign-in, public content routes, magic link, URL encoding

### DIFF
--- a/.github/workflows/linux-compat.yml
+++ b/.github/workflows/linux-compat.yml
@@ -105,14 +105,18 @@ jobs:
           echo "SPA (authenticated) status: $HTTP_CODE"
           [ "$HTTP_CODE" = "200" ] || (echo "FAIL: SPA didn't load with key" && exit 1)
 
-      - name: Smoke test - SPA auth gate (unauthenticated)
+      - name: Smoke test - SPA shell serves without auth (client-side gate)
         run: |
           RESPONSE=$(curl -s -w "\n%{http_code}" http://localhost:1934/browse)
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          echo "SPA (unauthenticated) status: $HTTP_CODE"
-          [ "$HTTP_CODE" = "401" ] || (echo "FAIL: expected 401 for unauthenticated SPA, got $HTTP_CODE" && exit 1)
-          BODY=$(echo "$RESPONSE" | head -n -1)
-          echo "$BODY" | grep -q "Sign in to continue" || (echo "FAIL: sign-in page not rendered" && exit 1)
+          echo "SPA shell (unauthenticated) status: $HTTP_CODE"
+          [ "$HTTP_CODE" = "200" ] || (echo "FAIL: expected 200 for SPA shell, got $HTTP_CODE" && exit 1)
+
+      - name: Smoke test - auth status reports unauthenticated
+        run: |
+          RESPONSE=$(curl -s http://localhost:1934/api/auth/status)
+          echo "Auth status response: $RESPONSE"
+          echo "$RESPONSE" | grep -q '"authenticated":false' || (echo "FAIL: expected authenticated:false" && exit 1)
 
       - name: Stop server
         if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -14727,7 +14727,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-server-openclaw",
-      "version": "0.10.8",
+      "version": "0.11.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.12",
@@ -14755,7 +14755,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-server",
-      "version": "3.10.15",
+      "version": "3.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/service/client/src/App.tsx
+++ b/packages/service/client/src/App.tsx
@@ -2,26 +2,60 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import { BrandingProvider } from '@/lib/BrandingProvider';
 import { AuthProvider } from '@/lib/auth';
+import { useAuth } from '@/lib/AuthContext';
 import { UndoProvider } from '@/lib/UndoContext';
 import { FileBrowser } from '@/pages/FileBrowser';
 import { Home } from '@/pages/Home';
 import { Runner } from '@/pages/Runner';
 import { RunnerJob } from '@/pages/RunnerJob';
+import { PublicContent } from '@/pages/PublicContent';
+import { SignIn } from '@/pages/SignIn';
+
+/** Render children when authenticated, SignIn page otherwise. */
+function AuthGate({ children }: { children: React.ReactNode }) {
+  const { loading, authenticated } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-muted-foreground text-sm">Loading…</div>
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return <SignIn />;
+  }
+
+  return <>{children}</>;
+}
 
 export default function App() {
   return (
     <BrandingProvider>
       <AuthProvider>
-        <UndoProvider>
-          <BrowserRouter>
+        <BrowserRouter>
+          <UndoProvider>
             <Routes>
-              <Route path="/runner/:jobId" element={<RunnerJob />} />
-              <Route path="/runner" element={<Runner />} />
-              <Route path="/browse/*" element={<FileBrowser />} />
-              <Route path="/" element={<Home />} />
+              <Route path="/readme" element={<PublicContent slug="readme" />} />
+              <Route path="/privacy" element={<PublicContent slug="privacy" />} />
+              <Route path="/terms" element={<PublicContent slug="terms" />} />
+              <Route
+                path="*"
+                element={
+                  <AuthGate>
+                    <Routes>
+                      <Route path="/runner/:jobId" element={<RunnerJob />} />
+                      <Route path="/runner" element={<Runner />} />
+                      <Route path="/browse/*" element={<FileBrowser />} />
+                      <Route path="/" element={<Home />} />
+                    </Routes>
+                  </AuthGate>
+                }
+              />
             </Routes>
-          </BrowserRouter>
-        </UndoProvider>
+          </UndoProvider>
+        </BrowserRouter>
       </AuthProvider>
     </BrandingProvider>
   );

--- a/packages/service/client/src/components/AccountMenu.tsx
+++ b/packages/service/client/src/components/AccountMenu.tsx
@@ -1,5 +1,6 @@
-import { ExternalLink, LogOut, User } from 'lucide-react';
+import { LogOut, Menu, Scale, Shield, User } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { useAuth } from '@/lib/AuthContext';
 
@@ -37,23 +38,11 @@ const BREAKPOINT_CLASS: Record<string, string> = {
 
 export function AccountMenu({ collapsedItems = [] }: AccountMenuProps) {
   const { authenticated, email, picture } = useAuth();
+  // Key-auth users (outsiders with ?key= URLs) are authenticated but don't
+  // have an account session. Show hamburger menu, not account avatar.
+  const hasSession = authenticated && !!email && !email.startsWith('key:');
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  const [privacyUrl, setPrivacyUrl] = useState<string | null>(null);
-  const [termsUrl, setTermsUrl] = useState<string | null>(null);
-
-  // Fetch content share links on mount
-  useEffect(() => {
-    fetch('/api/content-link/privacy')
-      .then((r) => r.json())
-      .then((data: { url?: string }) => { if (data.url) setPrivacyUrl(data.url); })
-      .catch(() => {});
-    fetch('/api/content-link/terms')
-      .then((r) => r.json())
-      .then((data: { url?: string }) => { if (data.url) setTermsUrl(data.url); })
-      .catch(() => {});
-  }, []);
-
   // Track whether a nested Radix dropdown is currently open
   const nestedDropdownOpen = useCallback(() => {
     return !!document.querySelector('[data-radix-popper-content-wrapper]');
@@ -80,8 +69,6 @@ export function AccountMenu({ collapsedItems = [] }: AccountMenuProps) {
     };
   }, [open, nestedDropdownOpen]);
 
-  if (!authenticated) return null;
-
   const initial = email ? email[0].toUpperCase() : '?';
 
   return (
@@ -89,29 +76,35 @@ export function AccountMenu({ collapsedItems = [] }: AccountMenuProps) {
       <button
         onClick={() => setOpen(!open)}
         className="flex items-center gap-2 px-2 py-1 rounded-md hover:bg-zinc-700 transition-colors"
-        title={email ?? 'Account'}
+        title={hasSession ? (email ?? 'Account') : 'Menu'}
       >
-        {picture ? (
-          <img src={picture} alt="" className="h-7 w-7 rounded-full" referrerPolicy="no-referrer" />
+        {hasSession ? (
+          picture ? (
+            <img src={picture} alt="" className="h-7 w-7 rounded-full" referrerPolicy="no-referrer" />
+          ) : (
+            <div className="h-7 w-7 rounded-full bg-blue-600 flex items-center justify-center text-white text-xs font-semibold">
+              {initial}
+            </div>
+          )
         ) : (
-          <div className="h-7 w-7 rounded-full bg-blue-600 flex items-center justify-center text-white text-xs font-semibold">
-            {initial}
-          </div>
+          <Menu className="h-5 w-5 text-zinc-300" />
         )}
       </button>
 
       {open && (
         <div className="absolute right-0 top-full mt-1 w-56 bg-popover border border-border rounded-lg shadow-lg z-50 py-1">
-          {/* User info — links to Google account */}
-          <a
-            href="https://myaccount.google.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 px-3 py-2 border-b border-border hover:bg-accent transition-colors"
-          >
-            <User className="h-4 w-4 text-foreground" />
-            <span className="text-sm text-foreground truncate">{email}</span>
-          </a>
+          {/* User info — links to Google account (session only) */}
+          {hasSession && (
+            <a
+              href="https://myaccount.google.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 px-3 py-2 border-b border-border hover:bg-accent transition-colors"
+            >
+              <User className="h-4 w-4 text-foreground" />
+              <span className="text-sm text-foreground truncate">{email}</span>
+            </a>
+          )}
 
           {/* Collapsed items — each visible in menu only below its breakpoint */}
           {collapsedItems.map((item, i) => (
@@ -120,46 +113,40 @@ export function AccountMenu({ collapsedItems = [] }: AccountMenuProps) {
             </div>
           ))}
 
-          {/* Separator before sign out if there are collapsed items */}
-          {collapsedItems.length > 0 && (
+          {/* Separator before sign out — only when there's content above AND below */}
+          {(hasSession || collapsedItems.length > 0) && hasSession && (
             <div className="border-b border-border" />
           )}
 
-          <a
-            href="/auth/logout"
-            className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-accent transition-colors"
-          >
-            <LogOut className="h-4 w-4" />
-            Sign out
-          </a>
-
-          {/* Legal links — share links to content/*.md */}
-          {(privacyUrl ?? termsUrl) && (
-            <div className="border-t border-border mt-1 pt-1">
-              {privacyUrl && (
-                <a
-                  href={privacyUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent transition-colors"
-                >
-                  <ExternalLink className="h-3 w-3" />
-                  Privacy
-                </a>
-              )}
-              {termsUrl && (
-                <a
-                  href={termsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent transition-colors"
-                >
-                  <ExternalLink className="h-3 w-3" />
-                  Terms
-                </a>
-              )}
-            </div>
+          {hasSession && (
+            <a
+              href="/auth/logout"
+              className="flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-accent transition-colors"
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </a>
           )}
+
+          {/* Legal links — only show separator when there's content above */}
+          <div className={hasSession || collapsedItems.length > 0 ? 'border-t border-border mt-1 pt-1' : ''}>
+            <Link
+              to="/privacy"
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent transition-colors"
+            >
+              <Shield className="h-3 w-3" />
+              Privacy
+            </Link>
+            <Link
+              to="/terms"
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:bg-accent transition-colors"
+            >
+              <Scale className="h-3 w-3" />
+              Terms
+            </Link>
+          </div>
         </div>
       )}
     </div>

--- a/packages/service/client/src/components/layout/Header.tsx
+++ b/packages/service/client/src/components/layout/Header.tsx
@@ -1,4 +1,13 @@
-import { Moon, Sun, BookOpen, KeyRound, GitBranch, Search, Activity } from 'lucide-react';
+import { Moon, Sun, BookOpen, KeyRound, Search, Activity } from 'lucide-react';
+
+/** GitHub mark (octicon) as an inline SVG component. */
+function GitHubLogo({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -18,6 +27,8 @@ interface HeaderProps {
   onToggleTheme: () => void;
   keyAge?: string | null;
   onRotateKey?: () => void;
+  /** When true, render the brand emoji as inert text instead of a home link. */
+  disableHomeLink?: boolean;
   /** Download dropdown for header bar (icon button variant) */
   downloadDropdown?: React.ReactNode;
   /** Link dropdown for header bar (icon button variant) */
@@ -36,6 +47,7 @@ export function Header({
   onToggleTheme,
   keyAge,
   onRotateKey,
+  disableHomeLink,
   downloadDropdown,
   linkControls,
   downloadMenuItem,
@@ -43,7 +55,7 @@ export function Header({
 }: HeaderProps) {
   const branding = useBranding();
   const hasKeyMgmt = isInsider && onRotateKey;
-  const [readmeUrl, setReadmeUrl] = useState<string | null>(null);
+
   const [searchOpen, setSearchOpen] = useState(false);
 
   // Ctrl/Cmd+K keyboard shortcut
@@ -61,12 +73,7 @@ export function Header({
     }
   }, [searchEnabled, isInsider, handleKeyDown]);
 
-  useEffect(() => {
-    fetch('/api/readme-link')
-      .then(r => r.ok ? r.json() as Promise<{ url: string }> : null)
-      .then(data => { if (data?.url) setReadmeUrl(data.url); })
-      .catch(() => {});
-  }, []);
+
 
   // Build account menu collapsed items in left-to-right header order
   const collapsedItems: CollapsedItem[] = [];
@@ -118,24 +125,22 @@ export function Header({
   }
 
   // README — hidden below md (768px)
-  if (readmeUrl) {
-    collapsedItems.push({
-      breakpoint: 'md',
-      node: (
-        <a href={readmeUrl} className={menuItemClass}>
-          <BookOpen className="h-4 w-4 shrink-0" />
-          README
-        </a>
-      ),
-    });
-  }
+  collapsedItems.push({
+    breakpoint: 'md',
+    node: (
+      <Link to="/readme" className={menuItemClass}>
+        <BookOpen className="h-4 w-4 shrink-0" />
+        README
+      </Link>
+    ),
+  });
 
   // GitHub — hidden below md (768px)
   collapsedItems.push({
     breakpoint: 'md',
     node: (
       <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" className={menuItemClass}>
-        <GitBranch className="h-4 w-4 shrink-0" />
+        <GitHubLogo className="h-4 w-4 shrink-0" />
         GitHub
       </a>
     ),
@@ -157,9 +162,13 @@ export function Header({
       <div className="flex items-center gap-1">
         {/* Breadcrumbs — takes remaining space, truncates */}
         <div className="flex items-center min-w-0 flex-1">
-          <Link to="/browse" className="text-3xl no-underline shrink-0 mr-1" title={branding.name}>
-            {branding.emoji}
-          </Link>
+          {disableHomeLink ? (
+            <span className="text-3xl shrink-0 mr-1" title={branding.name}>{branding.emoji}</span>
+          ) : (
+            <Link to="/browse" className="text-3xl no-underline shrink-0 mr-1" title={branding.name}>
+              {branding.emoji}
+            </Link>
+          )}
           <nav className="flex items-center gap-1 min-w-0 overflow-x-auto overflow-y-hidden scrollbar-thin">
             {breadcrumbs.map((crumb, i) => (
               <span key={crumb.path} className="flex items-center gap-1 shrink-0">
@@ -230,18 +239,16 @@ export function Header({
           )}
 
           {/* README: visible md+ (768px) */}
-          {readmeUrl && (
-            <a href={readmeUrl} title="README" className="hidden md:inline-flex">
-              <Button variant="ghost" size="icon" className="text-zinc-300 hover:text-white hover:bg-white/10 h-8 w-8">
-                <BookOpen className="h-4 w-4" />
-              </Button>
-            </a>
-          )}
+          <Link to="/readme" title="README" className="hidden md:inline-flex">
+            <Button variant="ghost" size="icon" className="text-zinc-300 hover:text-white hover:bg-white/10 h-8 w-8">
+              <BookOpen className="h-4 w-4" />
+            </Button>
+          </Link>
 
           {/* GitHub: visible md+ (768px) */}
           <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer" title="GitHub" className="hidden md:inline-flex">
             <Button variant="ghost" size="icon" className="text-zinc-300 hover:text-white hover:bg-white/10 h-8 w-8">
-              <GitBranch className="h-4 w-4" />
+              <GitHubLogo className="h-4 w-4" />
             </Button>
           </a>
 

--- a/packages/service/client/src/pages/PublicContent.tsx
+++ b/packages/service/client/src/pages/PublicContent.tsx
@@ -4,7 +4,6 @@
  */
 import { useEffect, useRef, useState } from 'react';
 
-import { DownloadDropdown } from '@/components/DownloadDropdown';
 import { Header } from '@/components/layout/Header';
 import { MarkdownView } from '@/components/MarkdownView';
 import { useTopBar } from '@/hooks/useTopBar';
@@ -27,24 +26,18 @@ export function PublicContent({ slug }: PublicContentProps) {
   const [file, setFile] = useState<FileContent | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [currentSlug, setCurrentSlug] = useState(slug);
-
-  // Reset state synchronously when slug changes (avoids setState in effect)
-  if (slug !== currentSlug) {
-    setCurrentSlug(slug);
-    setFile(null);
-    setLoading(true);
-    setError(null);
-  }
   const [mobileTocOpen, setMobileTocOpen] = useState(false);
   const mainRef = useRef<HTMLElement>(null);
   const { topBarRef, topBarHeight } = useTopBar();
 
   const title = TITLES[slug] ?? slug;
 
-  // Re-fetch when slug changes
+  // Reset and re-fetch when slug changes
   useEffect(() => {
     let cancelled = false;
+    setFile(null);
+    setLoading(true);
+    setError(null);
     const load = async () => {
       try {
         const r = await fetch(`/api/public-content/${slug}`);
@@ -77,29 +70,6 @@ export function PublicContent({ slug }: PublicContentProps) {
           theme={theme}
           onToggleTheme={toggleTheme}
           breadcrumbs={[{ label: title, path: slug }]}
-          downloadDropdown={
-            file ? (
-              <DownloadDropdown
-                reqPath={slug}
-                file={file}
-                variant="header"
-              />
-            ) : undefined
-          }
-          downloadMenuItem={
-            file
-              ? (onDismiss) => (
-                  <DownloadDropdown
-                    reqPath={slug}
-                    file={file}
-                    variant="menuItem"
-                    onStateChange={(s) => {
-                      if (s === 'done') setTimeout(onDismiss, 800);
-                    }}
-                  />
-                )
-              : undefined
-          }
         />
       </div>
 

--- a/packages/service/client/src/pages/PublicContent.tsx
+++ b/packages/service/client/src/pages/PublicContent.tsx
@@ -1,0 +1,144 @@
+/**
+ * PublicContent page — renders public markdown (privacy, terms, readme)
+ * without requiring authentication, reusing the same components as FileBrowser.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import { DownloadDropdown } from '@/components/DownloadDropdown';
+import { Header } from '@/components/layout/Header';
+import { MarkdownView } from '@/components/MarkdownView';
+import { useTopBar } from '@/hooks/useTopBar';
+import type { FileContent } from '@/lib/api';
+import { useTheme } from '@/lib/theme';
+
+interface PublicContentProps {
+  slug: string;
+}
+
+/** Map slug to a display title for breadcrumbs. */
+const TITLES: Record<string, string> = {
+  readme: 'User Guide',
+  privacy: 'Privacy Policy',
+  terms: 'Terms of Service',
+};
+
+export function PublicContent({ slug }: PublicContentProps) {
+  const [theme, toggleTheme] = useTheme();
+  const [file, setFile] = useState<FileContent | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentSlug, setCurrentSlug] = useState(slug);
+
+  // Reset state synchronously when slug changes (avoids setState in effect)
+  if (slug !== currentSlug) {
+    setCurrentSlug(slug);
+    setFile(null);
+    setLoading(true);
+    setError(null);
+  }
+  const [mobileTocOpen, setMobileTocOpen] = useState(false);
+  const mainRef = useRef<HTMLElement>(null);
+  const { topBarRef, topBarHeight } = useTopBar();
+
+  const title = TITLES[slug] ?? slug;
+
+  // Re-fetch when slug changes
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const r = await fetch(`/api/public-content/${slug}`);
+        if (!r.ok) throw new Error(`HTTP ${String(r.status)}`);
+        const data = (await r.json()) as FileContent;
+        if (!cancelled) {
+          setFile(data);
+          setLoading(false);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to load content',
+          );
+          setLoading(false);
+        }
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div ref={topBarRef} className="fixed top-0 left-0 right-0 z-50">
+        <Header
+          isInsider={false}
+          theme={theme}
+          onToggleTheme={toggleTheme}
+          breadcrumbs={[{ label: title, path: slug }]}
+          downloadDropdown={
+            file ? (
+              <DownloadDropdown
+                reqPath={slug}
+                file={file}
+                variant="header"
+              />
+            ) : undefined
+          }
+          downloadMenuItem={
+            file
+              ? (onDismiss) => (
+                  <DownloadDropdown
+                    reqPath={slug}
+                    file={file}
+                    variant="menuItem"
+                    onStateChange={(s) => {
+                      if (s === 'done') setTimeout(onDismiss, 800);
+                    }}
+                  />
+                )
+              : undefined
+          }
+        />
+      </div>
+
+      <main
+        ref={mainRef}
+        className="px-0 pb-32 overflow-y-auto"
+        style={{
+          marginTop: `${String(topBarHeight)}px`,
+          height: `calc(100vh - ${String(topBarHeight)}px)`,
+        }}
+      >
+        {loading && (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm py-8 justify-center">
+            Loading…
+          </div>
+        )}
+
+        {error && (
+          <div className="text-destructive text-sm p-6">
+            Failed to load content: {error}
+          </div>
+        )}
+
+        {file?.type === 'markdown' && file.html && (
+          <div className="px-4 md:px-6 pt-4">
+            <MarkdownView
+              fileRendered={file}
+              fileRaw={file}
+              reqPath={slug}
+              proseWidth="medium"
+              topBarHeight={topBarHeight}
+              mainRef={mainRef}
+              mobileTocOpen={mobileTocOpen}
+              setMobileTocOpen={setMobileTocOpen}
+              refetch={async () => {}}
+            />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/packages/service/client/src/pages/SignIn.tsx
+++ b/packages/service/client/src/pages/SignIn.tsx
@@ -1,0 +1,184 @@
+/**
+ * SPA sign-in page — shown when the user is not authenticated.
+ *
+ * Uses the real Header component (theme toggle only) and fetches
+ * auth modes from /status to decide which sign-in options to show.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Header } from '@/components/layout/Header';
+import { useBranding } from '@/lib/BrandingContext';
+import { useTheme } from '@/lib/theme';
+
+type AuthMode = 'google' | 'email' | 'keys';
+
+/** Google "G" logo SVG — official 4-color version. */
+function GoogleLogo({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+export function SignIn() {
+  const [theme, toggleTheme] = useTheme();
+  const branding = useBranding();
+  const [authModes, setAuthModes] = useState<AuthMode[]>([]);
+  const [emailSent, setEmailSent] = useState(false);
+  const [emailError, setEmailError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Fetch auth modes from /status
+  useEffect(() => {
+    fetch('/status')
+      .then((r) => (r.ok ? (r.json() as Promise<{ health?: { auth?: { modes?: AuthMode[] } } }>) : null))
+      .then((data) => {
+        const modes = data?.health?.auth?.modes;
+        if (modes) setAuthModes(modes);
+      })
+      .catch(() => {});
+  }, []);
+
+  const hasGoogle = authModes.includes('google');
+  const hasEmail = authModes.includes('email');
+  const returnTo = window.location.pathname + window.location.search;
+  const loginHref = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
+
+  const handleMagicLink = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const form = e.currentTarget;
+      const email = (form.elements.namedItem('email') as HTMLInputElement).value;
+      setEmailError('');
+      setSubmitting(true);
+      try {
+        const res = await fetch('/api/auth/magic', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, returnTo }),
+        });
+        if (res.ok) {
+          setEmailSent(true);
+        } else {
+          setEmailError('Something went wrong. Please try again.');
+        }
+      } catch {
+        setEmailError('Network error. Please try again.');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [returnTo],
+  );
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <Header
+        isInsider={false}
+        theme={theme}
+        onToggleTheme={toggleTheme}
+        disableHomeLink
+      />
+
+      <div className="flex-1 flex items-center justify-center px-5">
+        <div className="w-full max-w-sm text-center space-y-6">
+          <div>
+            <h1 className="text-2xl font-semibold text-foreground mb-1">
+              {branding.emoji} {branding.name}
+            </h1>
+            <h2 className="text-sm font-normal text-muted-foreground">
+              Sign in to continue
+            </h2>
+          </div>
+
+          <div className="text-sm text-muted-foreground">
+            Trying to access:
+            <br />
+            <code className="inline-block mt-1 px-1.5 py-0.5 bg-muted rounded text-xs break-all max-w-full">
+              {returnTo}
+            </code>
+          </div>
+
+          {/* Magic link email form */}
+          {hasEmail && !emailSent && (
+            <form onSubmit={handleMagicLink} className="space-y-3">
+              <input
+                type="email"
+                name="email"
+                placeholder="Enter your email"
+                required
+                className="w-full px-3 py-2.5 text-sm border border-border rounded-md bg-background text-foreground outline-none focus:border-primary transition-colors"
+              />
+              <button
+                type="submit"
+                disabled={submitting}
+                className="w-full px-6 py-2.5 bg-primary text-primary-foreground rounded-md text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+              >
+                {submitting ? 'Sending…' : 'Send Login Link'}
+              </button>
+              {emailError && (
+                <p className="text-sm text-destructive">{emailError}</p>
+              )}
+            </form>
+          )}
+
+          {hasEmail && emailSent && (
+            <p className="text-sm text-muted-foreground">
+              Check your email for a login link — if you&apos;re registered, one is on its way.
+            </p>
+          )}
+
+          {/* Divider */}
+          {hasEmail && hasGoogle && !emailSent && (
+            <div className="text-xs text-muted-foreground">— or —</div>
+          )}
+
+          {/* Google sign-in button — follows Google branding guidelines */}
+          {hasGoogle && (
+            <a
+              href={loginHref}
+              className="inline-flex items-center justify-center gap-3 w-full px-6 py-2.5 bg-white text-[#3c4043] rounded-md shadow-sm border border-[#dadce0] text-sm font-medium hover:shadow-md transition-shadow dark:bg-[#131314] dark:text-[#e3e3e3] dark:border-[#8e918f]"
+            >
+              <GoogleLogo className="w-[18px] h-[18px] shrink-0" />
+              Sign in with Google
+            </a>
+          )}
+
+          {!hasGoogle && !hasEmail && (
+            <p className="text-sm text-muted-foreground">
+              This server requires an API key for access.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <footer className="py-4 text-center">
+        <p className="text-xs text-muted-foreground space-x-3">
+          <Link to="/privacy" className="hover:underline">
+            Privacy Policy
+          </Link>
+          <Link to="/terms" className="hover:underline">
+            Terms of Service
+          </Link>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/packages/service/guides/index.md
+++ b/packages/service/guides/index.md
@@ -1,6 +1,7 @@
 ---
 title: Service Guides
 children:
+  - ./user-guide.md
   - ./setup.md
   - ./sharing.md
   - ./exports.md
@@ -12,6 +13,7 @@ children:
 
 # Service Guides
 
+- [User Guide](./user-guide.md) — Browsing, searching, sharing, exports, and keyboard shortcuts.
 - [Setup & Configuration](./setup.md) — Installation, auth modes, JSON config, named scopes, and config reference.
 - [Insiders, Outsiders & Sharing](./sharing.md) — The access model, HMAC key derivation, expiring links, and key rotation.
 - [Exporting & Downloads](./exports.md) — PDF, DOCX, SVG, PNG, and ZIP export via Puppeteer and bundled Mermaid/PlantUML.

--- a/packages/service/guides/user-guide.md
+++ b/packages/service/guides/user-guide.md
@@ -1,0 +1,191 @@
+# User Guide
+
+Welcome! This guide covers everything you need to know about using the file browser and document server.
+
+Your experience depends on how you access the server:
+
+- **[Insiders](#insider-experience)** — Authenticated users with a Google or email login. Full access to browsing, [search](#search), [sharing](#sharing), [exports](#downloads--exports), and [key management](#key-rotation).
+- **[Outsiders](#outsider-experience)** — Recipients of a share link. Read-only access to the specific file or directory that was shared with you, plus [exports](#downloads--exports).
+
+---
+
+## Signing In
+
+You can sign in using one of the available methods shown on the login page:
+
+- **Google** — Click the Google button to authenticate with your Google account.
+- **Email (Magic Link)** — Enter your email address and check your inbox for a one-time login link. The link expires after 10 minutes and can only be used once.
+
+Your administrator determines which sign-in methods are available. If you only see a message about an API key, contact your administrator for access.
+
+After signing in, you'll be redirected to the page you were originally trying to reach.
+
+---
+
+## Insider Experience
+
+Insiders have full authenticated access to the server. After [signing in](#signing-in), you can browse files, search documents, create share links, and export content.
+
+### Browsing Files
+
+The **file browser** is your home screen. Navigate through directories by clicking folder names. Click any file to view its contents. Use the breadcrumb trail in the header to navigate back up.
+
+### Supported File Types
+
+| Type | Extensions | Rendering |
+|------|-----------|-----------|
+| **Markdown** | `.md` | Full formatting, [table of contents](#table-of-contents), embedded [diagrams](#diagrams) |
+| **Code** | `.ts`, `.js`, `.py`, `.json`, etc. | Syntax highlighting with line numbers |
+| **CSV** | `.csv` | Formatted tables |
+| **SVG** | `.svg` | Interactive pan-and-zoom viewer |
+| **Mermaid diagrams** | `.mmd` | Rendered flowcharts, sequence diagrams, Gantt charts, etc. |
+| **PlantUML diagrams** | `.puml`, `.plantuml`, `.pu` | Rendered UML, architecture, and component diagrams |
+| **Images** | `.png`, `.jpg`, `.gif`, `.webp` | Displayed inline |
+| **Other files** | — | Available for [download](#downloads--exports) |
+
+### View Modes
+
+For files that support rendering (Markdown, CSV, SVG, diagrams), you can toggle between:
+
+- **Rendered** — Formatted output with full styling.
+- **Raw** — Source text with syntax highlighting.
+
+Use the tab bar below the header to switch views.
+
+### Table of Contents
+
+Markdown files with headings display a **table of contents** sidebar. On mobile, tap the TOC button in the tab bar to toggle it. Click any heading in the TOC to scroll directly to that section.
+
+### Prose Width
+
+Adjust the reading width of rendered Markdown using the width toggle in the tab bar. Three settings are available: narrow, medium, and wide.
+
+### Diagrams
+
+Diagrams can appear as standalone files or embedded in Markdown documents.
+
+**Standalone diagrams** (`.mmd`, `.puml`) are rendered with an interactive viewer that supports pan and zoom.
+
+**Embedded diagrams** are written in fenced code blocks within Markdown files:
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B[End]
+```
+
+```plantuml
+@startuml
+Alice -> Bob: Hello
+@enduml
+```
+````
+
+Both Mermaid and PlantUML are supported. Embedded diagrams are rendered inline alongside the surrounding text.
+
+### Search
+
+Use the **search** button in the header (or press `Ctrl+K` / `Cmd+K`) to search across all indexed documents. Results are ranked by relevance and show matching text snippets.
+
+Search supports filters for domains, authors, and other metadata when available. Search is only available to insiders.
+
+### Sharing
+
+Insiders can create links to share files or directories with [outsiders](#outsider-experience) — people who don't have an account.
+
+#### Creating Share Links
+
+1. Click the **link** icon in the header bar.
+2. Configure sharing options:
+   - **Expiry** — How long the link remains valid.
+   - **Depth** — For directories, how many levels deep the share extends.
+   - **Include directories** — Whether subdirectory listings are accessible.
+3. Copy the generated link.
+
+Share links are cryptographically signed and cannot be guessed. Each link is scoped to the specific path and sharing options you selected.
+
+#### Share Link Scope
+
+Your administrator may configure an **outsider policy** that restricts which paths can be shared externally. If a path is blocked by policy, the share dialog will indicate this.
+
+### Inline Editing
+
+Insiders can edit Markdown and text files directly in the browser:
+
+1. Switch to the **Raw** tab.
+2. Click the **Edit** button.
+3. Make your changes in the code editor.
+4. Press `Ctrl+Enter` to save, or click Cancel to discard.
+
+Undo/redo buttons appear in the tab bar after edits are saved.
+
+### Key Rotation
+
+Your access key is used to generate [share links](#sharing). If you need to invalidate all your existing share links (e.g., if a link was shared with the wrong person), you can **rotate your key** from the account menu.
+
+> ⚠️ Key rotation is permanent and cannot be undone. All share links you've previously created will stop working.
+
+---
+
+## Outsider Experience
+
+Outsiders access the server through a [share link](#sharing) created by an insider. No sign-in is required.
+
+### What You Can Do
+
+- **View** the shared file or directory (depending on the link's [scope](#share-link-scope)).
+- **Navigate** within shared directories (if directory listing was enabled in the share).
+- **Download** the shared content — see [Downloads & Exports](#downloads--exports).
+- **Toggle** between light and dark themes.
+
+### What You Can't Do
+
+- [Search](#search) across documents.
+- [Edit](#inline-editing) files.
+- Create [share links](#sharing) of your own.
+- Access any path outside the scope of your link.
+
+### Link Expiry
+
+Share links may have an expiry date set by the insider who created them. Expired links will no longer grant access. If you need continued access, ask the person who shared the link to create a new one.
+
+---
+
+## Downloads & Exports
+
+Click the **download** icon in the header to access export options. Available formats depend on the file type:
+
+| Source | Available Exports |
+|--------|------------------|
+| Markdown files | PDF, DOCX, Raw download |
+| Directories | ZIP archive |
+| Diagrams (Mermaid, PlantUML) | SVG, PNG |
+| Any file | Raw download |
+
+Both [insiders](#insider-experience) and [outsiders](#outsider-experience) can download and export content they have access to.
+
+---
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+K` / `Cmd+K` | Open [search](#search) (insiders only) |
+| `Ctrl+Enter` | Save when [editing](#inline-editing) |
+
+---
+
+## Getting Help
+
+If you need help with access, permissions, or configuration, contact your administrator or your AI assistant. Your assistant can help with tasks like setting up integrations, managing user access, and troubleshooting.
+
+### Further Reading
+
+These guides are written for server administrators but may be useful as reference:
+
+- [Setup & Configuration](https://docs.karmanivero.us/jeeves-server/documents/Service_Guides.Setup___Configuration.html) — Installation, auth modes, JSON config, named scopes, and config reference.
+- [Insiders, Outsiders & Sharing](https://docs.karmanivero.us/jeeves-server/documents/Service_Guides.Insiders__Outsiders___Sharing.html) — The access model, HMAC key derivation, expiring links, and key rotation.
+- [Exporting & Downloads](https://docs.karmanivero.us/jeeves-server/documents/Service_Guides.Exporting___Downloads.html) — PDF, DOCX, SVG, PNG, and ZIP export.
+- [Event Gateway](https://docs.karmanivero.us/jeeves-server/documents/Service_Guides.Event_Gateway.html) — Webhook receiving, JSON Schema matching, and durable queue processing.
+- [Deployment](https://docs.karmanivero.us/jeeves-server/documents/Service_Guides.Deployment.html) — Running as a service, reverse proxy setup, HTTPS, and updates.
+- [API & Integration](https://docs.karmanivero.us/jeeves-server/documents/Service_Guides.API___Integration.html) — Endpoint reference, share link generation, and AI assistant usage.

--- a/packages/service/src/auth/signInPage.test.ts
+++ b/packages/service/src/auth/signInPage.test.ts
@@ -8,7 +8,7 @@ describe('renderSignInPage', () => {
     expect(html).toContain('<title>');
     expect(html).toContain('Sign in to continue');
     expect(html).toContain('/browse/j/docs/readme.md');
-    expect(html).toContain('prefers-color-scheme: dark');
+    expect(html).toContain('.dark body');
   });
 
   it('renders Google sign-in link with encoded returnTo when google mode is active', () => {

--- a/packages/service/src/auth/signInPage.ts
+++ b/packages/service/src/auth/signInPage.ts
@@ -56,7 +56,7 @@ function submitMagic() {
   fetch('/api/auth/magic', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email: email, returnTo: ${JSON.stringify(requestUrl)} })
+    body: JSON.stringify({ email: email, returnTo: window.location.pathname + window.location.search })
   })
   .then(function(res) {
     if (res.ok) {

--- a/packages/service/src/auth/signInPage.ts
+++ b/packages/service/src/auth/signInPage.ts
@@ -56,7 +56,7 @@ function submitMagic() {
   fetch('/api/auth/magic', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email: email })
+    body: JSON.stringify({ email: email, returnTo: ${JSON.stringify(requestUrl)} })
   })
   .then(function(res) {
     if (res.ok) {
@@ -80,8 +80,9 @@ function submitMagic() {
       ? `<div class="divider"><span>— or —</span></div>`
       : '';
 
+  // Google-branded sign-in button with the colorful "G" logo
   const googleButtonHtml = hasGoogle
-    ? `<a href="${escapeHtml(loginHref)}" class="btn-secondary">Sign in with Google</a>`
+    ? `<a href="${escapeHtml(loginHref)}" class="btn-google"><svg class="google-logo" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>Sign in with Google</a>`
     : '';
 
   const noAuthHtml =
@@ -95,36 +96,74 @@ function submitMagic() {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${escapeHtml(brandEmoji)} ${escapeHtml(brandName)} — Sign In</title>
+<script>
+// Theme: match SPA behavior — read localStorage, fall back to system preference.
+(function() {
+  var saved = localStorage.getItem('jeeves-theme');
+  var theme = saved === 'dark' || saved === 'light' ? saved
+    : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  if (theme === 'dark') document.documentElement.classList.add('dark');
+})();
+</script>
 <style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
     font-family: system-ui, -apple-system, sans-serif;
-    margin: 80px auto;
-    padding: 0 20px;
-    text-align: center;
     color: #1a1a1a;
     background: #fff;
+  }
+  /* Header — matches SPA zinc-800 bar */
+  .header {
+    background: #27272a;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .header-brand {
+    font-size: 1.5rem;
+    text-decoration: none;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .header-brand-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #d4d4d8;
+  }
+  .theme-btn {
+    background: transparent;
+    border: none;
+    color: #d4d4d8;
+    cursor: pointer;
+    padding: 0.375rem;
+    border-radius: 0.25rem;
+    display: flex;
+    align-items: center;
+    transition: color 0.15s, background 0.15s;
+  }
+  .theme-btn:hover { color: #fff; background: rgba(255,255,255,0.1); }
+  .theme-btn svg { width: 1rem; height: 1rem; }
+  /* Moon icon hidden in dark mode, sun icon hidden in light mode */
+  .icon-sun { display: none; }
+  .icon-moon { display: block; }
+  .dark .icon-sun { display: block; }
+  .dark .icon-moon { display: none; }
+  /* Content */
+  .content {
+    margin: 60px auto;
+    padding: 0 20px;
+    text-align: center;
   }
   .box {
     max-width: 400px;
     margin: 0 auto;
   }
-  @media (prefers-color-scheme: dark) {
-    body { color: #e0e0e0; background: #1a1a1a; }
-    code { background: #2a2a2a; }
-    .email-input { background: #2a2a2a; color: #e0e0e0; border-color: #444; }
-    .email-input:focus { border-color: #4285f4; }
-    .btn-secondary {
-      background: transparent;
-      color: #e0e0e0;
-      border-color: #555;
-    }
-    .btn-secondary:hover { border-color: #e0e0e0; }
-    .muted { color: #999; }
-    .divider { color: #555; }
-  }
   h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.25rem; }
   h2 { font-size: 1rem; font-weight: 400; color: #666; margin-top: 0; margin-bottom: 1.25rem; }
-  @media (prefers-color-scheme: dark) { h2 { color: #999; } }
   code {
     display: inline-block;
     max-width: 100%;
@@ -136,11 +175,9 @@ function submitMagic() {
     font-size: 0.85rem;
   }
   .url-block { margin-bottom: 1.5rem; font-size: 0.9rem; color: #666; }
-  @media (prefers-color-scheme: dark) { .url-block { color: #999; } }
   .email-input {
     display: block;
     width: 100%;
-    box-sizing: border-box;
     padding: 10px 12px;
     font-size: 0.95rem;
     border: 1px solid #ccc;
@@ -167,19 +204,25 @@ function submitMagic() {
     transition: background 0.15s;
   }
   .btn-primary:hover { background: #3367d6; }
-  .btn-secondary {
-    display: block;
+  /* Google-branded button */
+  .btn-google {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
     padding: 10px 24px;
-    background: transparent;
-    color: #1a1a1a;
+    background: #fff;
+    color: #3c4043;
     text-decoration: none;
-    border: 1px solid #ccc;
+    border: 1px solid #dadce0;
     border-radius: 4px;
     font-size: 0.95rem;
     font-weight: 500;
-    transition: border-color 0.15s;
+    cursor: pointer;
+    transition: background 0.15s, box-shadow 0.15s;
   }
-  .btn-secondary:hover { border-color: #1a1a1a; }
+  .btn-google:hover { background: #f7f8f8; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .google-logo { width: 18px; height: 18px; flex-shrink: 0; }
   .divider {
     margin: 1rem 0;
     font-size: 0.85rem;
@@ -192,9 +235,28 @@ function submitMagic() {
   }
   .muted { font-size: 0.95rem; color: #666; line-height: 1.5; }
   .action { margin-top: 0.25rem; }
+  /* Dark mode overrides (class-based, matches SPA) */
+  .dark body { color: #e0e0e0; background: #1a1a1a; }
+  .dark h2 { color: #999; }
+  .dark code { background: #2a2a2a; }
+  .dark .url-block { color: #999; }
+  .dark .email-input { background: #2a2a2a; color: #e0e0e0; border-color: #444; }
+  .dark .email-input:focus { border-color: #4285f4; }
+  .dark .btn-google { background: #fff; color: #3c4043; border-color: #dadce0; }
+  .dark .btn-google:hover { background: #f7f8f8; }
+  .dark .muted { color: #999; }
+  .dark .divider { color: #555; }
 </style>
 </head>
 <body>
+<header class="header">
+  <span class="header-brand">${escapeHtml(brandEmoji)} <span class="header-brand-name">${escapeHtml(brandName)}</span></span>
+  <button class="theme-btn" id="themeToggle" title="Toggle theme">
+    <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+  </button>
+</header>
+<div class="content">
 <div class="box">
 <h1>${escapeHtml(brandEmoji)} ${escapeHtml(brandName)}</h1>
 <h2>Sign in to continue</h2>
@@ -202,6 +264,14 @@ function submitMagic() {
 ${emailFormHtml}${dividerHtml}
 <div class="action">${googleButtonHtml}${noAuthHtml}</div>
 </div>
+</div>
+<script>
+document.getElementById('themeToggle').addEventListener('click', function() {
+  var html = document.documentElement;
+  var isDark = html.classList.toggle('dark');
+  localStorage.setItem('jeeves-theme', isDark ? 'dark' : 'light');
+});
+</script>
 </body>
 </html>`;
 }

--- a/packages/service/src/dev-server.ts
+++ b/packages/service/src/dev-server.ts
@@ -4,9 +4,21 @@
  */
 import { init } from '@karmaniverous/jeeves';
 
+import { initConfig } from './config/index.js';
+
 init({
   workspacePath: process.env.JEEVES_WORKSPACE_PATH || 'J:\\jeeves',
   configRoot: process.env.JEEVES_CONFIG_ROOT || 'J:\\config',
 });
+
+// Pre-initialize config so server.ts finds it ready.
+// In dev, default to the prod config path (port override keeps them separate).
+const configPath =
+  process.env.JEEVES_SERVER_CONFIG || 'J:\\config\\jeeves-server\\config.json';
+const config = initConfig(configPath);
+
+// Override port for dev to avoid colliding with the prod service.
+const devPort = Number(process.env.JEEVES_SERVER_PORT) || 19340;
+(config as { port: number }).port = devPort;
 
 await import('./server.js');

--- a/packages/service/src/dev-server.ts
+++ b/packages/service/src/dev-server.ts
@@ -19,6 +19,6 @@ const config = initConfig(configPath);
 
 // Override port for dev to avoid colliding with the prod service.
 const devPort = Number(process.env.JEEVES_SERVER_PORT) || 19340;
-(config as { port: number }).port = devPort;
+config.port = devPort;
 
 await import('./server.js');

--- a/packages/service/src/routes/api/index.ts
+++ b/packages/service/src/routes/api/index.ts
@@ -17,6 +17,7 @@ import { linkInfoRoutes } from './linkInfo.js';
 import { magicLinkApiRoute } from './magicLink.js';
 import { addAuthMiddleware } from './middleware.js';
 import { oauthApiRoutes } from './oauth.js';
+import { publicContentRoute } from './publicContent.js';
 import { rawRoutes } from './raw.js';
 import { runnerRoutes } from './runner.js';
 import { searchRoutes } from './search.js';
@@ -42,4 +43,5 @@ export const apiRoute: FastifyPluginAsync = async (fastify) => {
   await fastify.register(fileMutationRoutes);
   await fastify.register(magicLinkApiRoute);
   await fastify.register(oauthApiRoutes);
+  await fastify.register(publicContentRoute);
 };

--- a/packages/service/src/routes/api/magicLink.ts
+++ b/packages/service/src/routes/api/magicLink.ts
@@ -12,6 +12,7 @@ import crypto from 'node:crypto';
 
 import type { FastifyPluginAsync } from 'fastify';
 
+import { sanitizeReturnTo } from '../../auth/resolve.js';
 import { getConfig } from '../../config/index.js';
 import { DEFAULT_BRANDING } from '../../config/schema.js';
 import { sendMagicLinkEmail } from '../../services/email.js';
@@ -30,7 +31,9 @@ export const magicLinkApiRoute: FastifyPluginAsync = async (fastify) => {
         return reply.code(200).send({ ok: true });
       }
 
-      const returnTo = request.body.returnTo;
+      const returnTo = request.body.returnTo
+        ? sanitizeReturnTo(request.body.returnTo)
+        : undefined;
 
       // Check if email matches a configured insider
       const insider = config.resolvedInsiders.find(

--- a/packages/service/src/routes/api/magicLink.ts
+++ b/packages/service/src/routes/api/magicLink.ts
@@ -19,8 +19,8 @@ import { storeMagicToken } from '../../services/magicLinkState.js';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const magicLinkApiRoute: FastifyPluginAsync = async (fastify) => {
-  fastify.post<{ Body: { email?: string } }>(
-    '/auth/magic',
+  fastify.post<{ Body: { email?: string; returnTo?: string } }>(
+    '/api/auth/magic',
     async (request, reply) => {
       const config = getConfig();
 
@@ -30,6 +30,8 @@ export const magicLinkApiRoute: FastifyPluginAsync = async (fastify) => {
         return reply.code(200).send({ ok: true });
       }
 
+      const returnTo = request.body.returnTo;
+
       // Check if email matches a configured insider
       const insider = config.resolvedInsiders.find(
         (i) => i.email.toLowerCase() === email,
@@ -38,7 +40,7 @@ export const magicLinkApiRoute: FastifyPluginAsync = async (fastify) => {
       if (insider && config.authModes.includes('email') && config.emailAuth) {
         // Generate a secure token
         const token = crypto.randomBytes(32).toString('hex');
-        storeMagicToken(token, { email });
+        storeMagicToken(token, { email, returnTo });
 
         // Build the magic link URL
         const proto =

--- a/packages/service/src/routes/api/middleware.ts
+++ b/packages/service/src/routes/api/middleware.ts
@@ -77,16 +77,29 @@ export function addAuthMiddleware(fastify: FastifyInstance): void {
     const query = request.query as AuthQuery;
     const deepParams = extractDeepParams(query);
 
-    const urlPath = decodeURIComponent(
-      request.url
+    let urlPath: string;
+    try {
+      urlPath = decodeURIComponent(
+        request.url
+          .split('?')[0]
+          .replace('/api/path', '')
+          .replace('/api/drives', '/')
+          .replace('/api/file', '')
+          .replace('/api/raw', '')
+          .replace('/api/export-cache', '')
+          .replace('/api/export', ''),
+      );
+    } catch {
+      // Malformed percent-encoding — use the raw path
+      urlPath = request.url
         .split('?')[0]
         .replace('/api/path', '')
         .replace('/api/drives', '/')
         .replace('/api/file', '')
         .replace('/api/raw', '')
         .replace('/api/export-cache', '')
-        .replace('/api/export', ''),
-    );
+        .replace('/api/export', '');
+    }
 
     // Try key-based auth
     let authResult = resolveKeyAuth(

--- a/packages/service/src/routes/api/middleware.ts
+++ b/packages/service/src/routes/api/middleware.ts
@@ -26,6 +26,7 @@ export function addAuthMiddleware(fastify: FastifyInstance): void {
     if (request.url.startsWith('/api/content-link/')) return;
     if (request.url.startsWith('/api/auth/status')) return;
     if (request.url.startsWith('/api/auth/magic')) return;
+    if (request.url.startsWith('/api/public-content/')) return;
     if (request.url.startsWith('/api/diagram/')) return;
     if (request.url.startsWith('/api/status')) return;
 
@@ -76,14 +77,16 @@ export function addAuthMiddleware(fastify: FastifyInstance): void {
     const query = request.query as AuthQuery;
     const deepParams = extractDeepParams(query);
 
-    const urlPath = request.url
-      .split('?')[0]
-      .replace('/api/path', '')
-      .replace('/api/drives', '/')
-      .replace('/api/file', '')
-      .replace('/api/raw', '')
-      .replace('/api/export-cache', '')
-      .replace('/api/export', '');
+    const urlPath = decodeURIComponent(
+      request.url
+        .split('?')[0]
+        .replace('/api/path', '')
+        .replace('/api/drives', '/')
+        .replace('/api/file', '')
+        .replace('/api/raw', '')
+        .replace('/api/export-cache', '')
+        .replace('/api/export', ''),
+    );
 
     // Try key-based auth
     let authResult = resolveKeyAuth(

--- a/packages/service/src/routes/api/publicContent.ts
+++ b/packages/service/src/routes/api/publicContent.ts
@@ -5,7 +5,7 @@
  * No authentication required.
  */
 
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -20,7 +20,6 @@ const serverRoot = packageDirectorySync({ cwd: __dirname }) ?? __dirname;
 /** Allowed slug pattern — alphanumeric, hyphens, underscores only. */
 const SLUG_RE = /^[\w-]+$/;
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export const publicContentRoute: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Params: { slug: string } }>(
     '/api/public-content/:slug',
@@ -37,11 +36,13 @@ export const publicContentRoute: FastifyPluginAsync = async (fastify) => {
           ? path.join(serverRoot, 'guides', 'user-guide.md')
           : path.join(serverRoot, 'content', `${slug}.md`);
 
-      if (!fs.existsSync(filePath)) {
+      let markdown: string;
+      try {
+        markdown = await fs.readFile(filePath, 'utf8');
+      } catch {
         return reply.code(404).send({ error: 'Not found' });
       }
 
-      const markdown = fs.readFileSync(filePath, 'utf8');
       const { html, headings } = parseMarkdown(markdown, {
         linkWindowsPaths: false,
       });

--- a/packages/service/src/routes/api/publicContent.ts
+++ b/packages/service/src/routes/api/publicContent.ts
@@ -1,0 +1,62 @@
+/**
+ * Public content API route — serves rendered markdown for public pages.
+ *
+ * Handles: GET /api/public-content/:slug
+ * No authentication required.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { FastifyPluginAsync } from 'fastify';
+import { packageDirectorySync } from 'package-directory';
+
+import { parseMarkdown } from '../../services/markdown.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverRoot = packageDirectorySync({ cwd: __dirname }) ?? __dirname;
+
+/** Allowed slug pattern — alphanumeric, hyphens, underscores only. */
+const SLUG_RE = /^[\w-]+$/;
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const publicContentRoute: FastifyPluginAsync = async (fastify) => {
+  fastify.get<{ Params: { slug: string } }>(
+    '/api/public-content/:slug',
+    async (request, reply) => {
+      const { slug } = request.params;
+
+      if (!SLUG_RE.test(slug)) {
+        return reply.code(400).send({ error: 'Invalid slug' });
+      }
+
+      // readme → guides/user-guide.md; everything else → content/{slug}.md
+      const filePath =
+        slug === 'readme'
+          ? path.join(serverRoot, 'guides', 'user-guide.md')
+          : path.join(serverRoot, 'content', `${slug}.md`);
+
+      if (!fs.existsSync(filePath)) {
+        return reply.code(404).send({ error: 'Not found' });
+      }
+
+      const markdown = fs.readFileSync(filePath, 'utf8');
+      const { html, headings } = parseMarkdown(markdown, {
+        linkWindowsPaths: false,
+      });
+
+      // Return FileContent-shaped response so the SPA can reuse
+      // FileContentView / MarkdownView directly.
+      return reply.send({
+        type: 'markdown',
+        content: markdown,
+        html,
+        headings,
+        fileName: `${slug}.md`,
+        breadcrumbs: [],
+        isInsider: false,
+      });
+    },
+  );
+};

--- a/packages/service/src/routes/magicCallback.ts
+++ b/packages/service/src/routes/magicCallback.ts
@@ -14,6 +14,7 @@ import crypto from 'node:crypto';
 import type { FastifyPluginAsync } from 'fastify';
 
 import { renderErrorPage } from '../auth/errorPage.js';
+import { sanitizeReturnTo } from '../auth/resolve.js';
 import { setSessionCookie } from '../auth/session.js';
 import { getConfig, resetConfig } from '../config/index.js';
 import { consumeMagicToken } from '../services/magicLinkState.js';
@@ -87,7 +88,7 @@ export const magicCallbackRoute: FastifyPluginAsync = async (fastify) => {
       setSessionCookie(reply, request, pending.email, sessionSecret);
 
       // Redirect to the originally requested path, or /browse as fallback.
-      const returnTo = pending.returnTo || '/browse';
+      const returnTo = sanitizeReturnTo(pending.returnTo || '/browse');
       return reply.redirect(returnTo);
     },
   );

--- a/packages/service/src/routes/magicCallback.ts
+++ b/packages/service/src/routes/magicCallback.ts
@@ -86,7 +86,9 @@ export const magicCallbackRoute: FastifyPluginAsync = async (fastify) => {
       // Set session cookie (identical shape to Google OAuth sessions)
       setSessionCookie(reply, request, pending.email, sessionSecret);
 
-      return reply.redirect('/browse');
+      // Redirect to the originally requested path, or /browse as fallback.
+      const returnTo = pending.returnTo || '/browse';
+      return reply.redirect(returnTo);
     },
   );
 };

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -12,15 +12,7 @@ import fastifyStatic from '@fastify/static';
 import { getBindAddress } from '@karmaniverous/jeeves';
 import Fastify, { type FastifyReply, type FastifyRequest } from 'fastify';
 
-import {
-  type AuthQuery,
-  extractDeepParams,
-  resolveKeyAuth,
-  resolveSessionAuth,
-} from './auth/resolve.js';
-import { renderSignInPage } from './auth/signInPage.js';
 import { getConfig, initConfig, isConfigInitialized } from './config/index.js';
-import { getEffectiveAuthModes } from './config/types.js';
 import { apiRoute } from './routes/api/index.js';
 import { authRoute } from './routes/auth.js';
 import { registerConfigRoute } from './routes/config.js';
@@ -96,45 +88,14 @@ async function start() {
         prefix: '/app/',
       });
 
-      // Auth-gated SPA fallback — serves index.html for authenticated users,
-      // branded sign-in page for unauthenticated users (#214)
+      // SPA fallback — always serve index.html for SPA routes.
+      // Auth gating is handled client-side by the React AuthGate component,
+      // which checks /api/auth/status and renders SignIn when unauthenticated.
       const spaFallback = async (
-        request: FastifyRequest,
+        _request: FastifyRequest,
         reply: FastifyReply,
       ) => {
-        const cfg = getConfig();
-        const query = request.query as AuthQuery;
-
-        // Extract the browse path from the URL for path-scoped key verification.
-        // /browse/j/docs/readme.md → j/docs/readme.md
-        // /browse or /browse/ → /
-        const urlPath =
-          request.url.split('?')[0].replace(/^\/(browse|runner)(\/|$)/, '') ||
-          '/';
-
-        const keyResult = resolveKeyAuth(
-          cfg,
-          urlPath,
-          query.key,
-          query.exp,
-          extractDeepParams(query),
-        );
-        const sessionResult = resolveSessionAuth(cfg, request);
-
-        if (keyResult.valid || sessionResult.valid) {
-          return reply.sendFile('index.html', clientDir);
-        }
-
-        return reply
-          .type('text/html')
-          .code(401)
-          .send(
-            renderSignInPage(
-              request.url,
-              getEffectiveAuthModes(cfg),
-              cfg.branding,
-            ),
-          );
+        return reply.sendFile('index.html', clientDir);
       };
 
       for (const route of [
@@ -143,6 +104,9 @@ async function start() {
         '/browse/*',
         '/runner',
         '/runner/*',
+        '/readme',
+        '/privacy',
+        '/terms',
       ]) {
         fastify.get(route, spaFallback);
       }

--- a/packages/service/src/services/magicLinkState.ts
+++ b/packages/service/src/services/magicLinkState.ts
@@ -8,6 +8,7 @@ import { createTtlStateMap } from './ttlStateMap.js';
 /** Data stored for a pending magic link token. */
 export interface PendingMagicLink {
   email: string;
+  returnTo?: string;
 }
 
 const map = createTtlStateMap<PendingMagicLink>(10 * 60 * 1000);


### PR DESCRIPTION
## Summary

Fixes magic link 404, dark mode sign-in button, and moves auth gating from server-rendered HTML to the SPA for DRY component reuse. Adds public content routes and a user guide.

## Changes

### Bug Fixes
- **Magic link 404** — route path /auth/magic → /api/auth/magic
- **Magic link returnTo** — preserves original path through auth flow
- **URL encoding** — decodeURIComponent in middleware path extraction fixes outsider shares with spaces/special chars
- **Dark mode Google button** — proper Google-branded button with dark mode variant

### SPA Sign-In (DRY refactor)
- Removed server-rendered sign-in page; auth gating now handled client-side by AuthGate component
- SignIn page reuses real Header component (theme toggle, hamburger menu)
- BrowserRouter moved above AuthGate so Header's <Link> components have router context
- UndoProvider moved above routes so MarkdownView works on public pages

### Public Content Routes
- New /readme, /privacy, /terms routes served through the SPA without authentication
- New PublicContent page component reuses MarkdownView (TOC, prose width) and Header
- New GET /api/public-content/:slug endpoint serves rendered markdown from bundled content
- User guide at guides/user-guide.md with insider/outsider sections, anchor links, docs site links
- Header README/privacy/terms links now use clean routes (no outsider key URLs)

### Header & Menu
- GitHub octocat SVG logo replacing GitBranch icon
- disableHomeLink prop on Header (used only on sign-in page)
- AccountMenu shows hamburger for unauthenticated and key-auth (outsider) users
- Privacy (Shield icon) and Terms (Scale icon) links in menu
- No empty separators when menu sections are empty

### Dev Server
- dev-server.ts pre-initializes config from prod config path with port override for dev