### PR TITLE
fix: include guides/ in package files (fixes /readme 404)

### DIFF
--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -57,6 +57,7 @@
   "files": [
     "dist",
     "content",
+    "guides",
     "scripts"
   ],
   "keywords": [


### PR DESCRIPTION
## Problem

The \/readme\ route returns 404 on production instances.

**Root cause:** The \guides/\ directory is not listed in \package.json\ \iles\, so it is excluded from the published npm package. The \/api/public-content/readme\ handler resolves \guides/user-guide.md\ via \packageDirectorySync()\, but the file doesn't exist in the installed package.

## Fix

Add \guides\ to the \iles\ array in \packages/service/package.json\.

Closes #242