### PR TITLE
[SERVER-312] fix: resolve-path route /api/ prefix

### DIFF
--- a/packages/service/src/routes/api/resolvePath.ts
+++ b/packages/service/src/routes/api/resolvePath.ts
@@ -20,7 +20,7 @@ export const resolvePathRoutes: FastifyPluginCallback = (
   _opts,
   done,
 ) => {
-  fastify.get('/resolve-path', async (request, reply) => {
+  fastify.get('/api/resolve-path', async (request, reply) => {
     const { fsPath } = request.query as { fsPath?: string };
 
     if (!fsPath) {


### PR DESCRIPTION
The resolve-path route was registered at \/resolve-path\ while every other API route uses the \/api/\ prefix explicitly (e.g. \/api/drives\, \/api/path/*\). The auth middleware bypass already checks for \/api/resolve-path\, and meta's progress reporter calls \/api/resolve-path\ — resulting in a 404 from the Fastify not-found handler.

**Fix:** Change the route from \/resolve-path\ to \/api/resolve-path\.

Tests pass (14/14).