### PR TITLE
fix: SPA auth gate path prefix for share keys

### DIFF
--- a/packages/service/src/auth/resolve.ts
+++ b/packages/service/src/auth/resolve.ts
@@ -210,7 +210,12 @@ export function resolveAuth(
   // Key param fallback — handles outsider share links
   const query = request.query as AuthQuery;
   const deepParams = extractDeepParams(query);
-  const urlPath = request.url.split('?')[0];
+  let urlPath = request.url.split('?')[0];
+  if (urlPath.startsWith('/browse')) {
+    urlPath = urlPath.substring('/browse'.length) || '/';
+  } else if (urlPath.startsWith('/runner')) {
+    urlPath = urlPath.substring('/runner'.length) || '/';
+  }
   const keyResult = resolveKeyAuth(
     config,
     urlPath,


### PR DESCRIPTION
The server-side auth gate (#253) passes the full URL path including the \/browse\ or \/runner\ prefix to \esolveKeyAuth\, but share keys are computed against the path *without* the prefix. HMAC mismatch → auth returns \
one\ → sign-in page for every share link.

Strips \/browse\ and \/runner\ prefixes before key verification, matching the path normalization used everywhere else.